### PR TITLE
API-004: 招待参加（POST /api/households/join）

### DIFF
--- a/web/app/api/households/join/route.ts
+++ b/web/app/api/households/join/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { getSession } from '@/server/utils/auth'
+import { badRequest, normalizeError, toErrorBody } from '@/server/utils/errors'
+import { inviteService } from '@/server/services/inviteService'
+import { householdsRepository } from '@/server/repositories/householdsRepository'
+
+type Body = { token: string }
+
+export async function POST(req: NextRequest) {
+  try {
+    const session = await getSession(req)
+
+    const json = (await req.json().catch(() => ({}))) as Partial<Body>
+    if (!json.token || typeof json.token !== 'string') {
+      throw badRequest('token is required and must be a string')
+    }
+
+    const payload = inviteService.verifyToken(json.token)
+
+    await householdsRepository.join(session.userId, payload.household_id)
+
+    return NextResponse.json({ household_id: payload.household_id }, { status: 200 })
+  } catch (e: unknown) {
+    const err = normalizeError(e)
+    return NextResponse.json(toErrorBody(err), { status: err.status })
+  }
+}
+

--- a/web/server/repositories/householdsRepository.ts
+++ b/web/server/repositories/householdsRepository.ts
@@ -33,5 +33,23 @@ export const householdsRepository = {
 
     return { id: hh.id, name: hh.name }
   },
+
+  async join(userId: string, householdId: string): Promise<void> {
+    const supabase = createSupabaseAdmin()
+    // Upsert to avoid duplicate unique (household_id, user_id) violation
+    const { error } = await supabase
+      .from('household_members')
+      .upsert(
+        {
+          household_id: householdId,
+          user_id: userId,
+          role: 'member',
+          joined_at: new Date().toISOString(),
+        },
+        { onConflict: 'household_id,user_id', ignoreDuplicates: true },
+      )
+
+    if (error) throw error
+  },
 }
 

--- a/web/tests/api/households_join.test.ts
+++ b/web/tests/api/households_join.test.ts
@@ -22,6 +22,7 @@ vi.mock('@/server/repositories/householdsRepository', () => ({
 import * as authModule from '@/server/utils/auth'
 import type { Session } from '@/server/utils/auth'
 import * as inviteModule from '@/server/services/inviteService'
+import type { InvitePayload } from '@/server/services/inviteService'
 import * as repoModule from '@/server/repositories/householdsRepository'
 import { unauthorized, badRequest } from '@/server/utils/errors'
 
@@ -77,12 +78,13 @@ describe('POST /api/households/join', () => {
   it('joins household and returns 200 with household_id', async () => {
     const session: Session = { userId: 'u-1', token: 't' }
     getSession.mockResolvedValue(session)
-    inviteService.verifyToken.mockReturnValue({
+    const payload: InvitePayload = {
       household_id: 'h-1',
       inviter: 'u-2',
       iat: Math.floor(Date.now()/1000) - 10,
       exp: Math.floor(Date.now()/1000) + 3600,
-    } as any)
+    }
+    inviteService.verifyToken.mockReturnValue(payload)
     householdsRepository.join.mockResolvedValue(undefined)
 
     const req = makeReq({ token: 'tok-abc' })

--- a/web/tests/api/households_join.test.ts
+++ b/web/tests/api/households_join.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+import * as route from '@/app/api/households/join/route'
+
+vi.mock('@/server/utils/auth', () => ({
+  getSession: vi.fn(),
+}))
+
+vi.mock('@/server/services/inviteService', () => ({
+  inviteService: {
+    verifyToken: vi.fn(),
+  },
+}))
+
+vi.mock('@/server/repositories/householdsRepository', () => ({
+  householdsRepository: {
+    join: vi.fn(),
+  },
+}))
+
+import * as authModule from '@/server/utils/auth'
+import type { Session } from '@/server/utils/auth'
+import * as inviteModule from '@/server/services/inviteService'
+import * as repoModule from '@/server/repositories/householdsRepository'
+import { unauthorized, badRequest } from '@/server/utils/errors'
+
+function makeReq(body: unknown, headers: Record<string, string> = {}): NextRequest {
+  const h = new Headers(headers)
+  return {
+    headers: h,
+    json: async () => body,
+  } as unknown as NextRequest
+}
+
+describe('POST /api/households/join', () => {
+  const getSession = vi.mocked(authModule.getSession)
+  const inviteService = vi.mocked(inviteModule.inviteService)
+  const householdsRepository = vi.mocked(repoModule.householdsRepository)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 401 when unauthorized', async () => {
+    getSession.mockRejectedValue(unauthorized())
+    const req = makeReq({})
+    const res = await route.POST(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 400 when token is missing or wrong type', async () => {
+    const session: Session = { userId: 'u-1', token: 't' }
+    getSession.mockResolvedValue(session)
+    const req = makeReq({})
+    const res = await route.POST(req)
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('returns 400 when token is invalid', async () => {
+    const session: Session = { userId: 'u-1', token: 't' }
+    getSession.mockResolvedValue(session)
+    inviteService.verifyToken.mockImplementation(() => { throw badRequest('invalid') })
+    const req = makeReq({ token: 'bad' })
+    const res = await route.POST(req)
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('joins household and returns 200 with household_id', async () => {
+    const session: Session = { userId: 'u-1', token: 't' }
+    getSession.mockResolvedValue(session)
+    inviteService.verifyToken.mockReturnValue({
+      household_id: 'h-1',
+      inviter: 'u-2',
+      iat: Math.floor(Date.now()/1000) - 10,
+      exp: Math.floor(Date.now()/1000) + 3600,
+    } as any)
+    householdsRepository.join.mockResolvedValue(undefined)
+
+    const req = makeReq({ token: 'tok-abc' })
+    const res = await route.POST(req)
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual({ household_id: 'h-1' })
+    expect(householdsRepository.join).toHaveBeenCalledWith('u-1', 'h-1')
+  })
+})
+


### PR DESCRIPTION
## 実装内容
- 招待参加API `POST /api/households/join` を実装
- 招待トークン検証 `inviteService.verifyToken` を使用
- household_members への参加処理を Repository に追加（重複時は無視して安全に参加）
- 単体テスト追加（正常/未認証/バリデーション/不正トークン）

## 参照設計書
- docs/design/base/v1.0/api.md
- docs/design/detail/v1.0/feature/api_detail.md

## テスト結果
- [x] 単体テスト: 通過
- [ ] 統合テスト: 未実施
- [ ] 手動テスト: 未実施

## 確認事項
- [x] コードレビュー対象
- [x] 設計書との整合性確認
- [ ] パフォーマンス確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * You can now join a household using an invite token; successful requests add you as a member and return the household ID.
  * Requests return clear, appropriate error responses for missing/invalid tokens or unauthorized access.
* **Tests**
  * Added tests covering auth failures, input validation, token verification failures, and successful join flow with response assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->