### PR TITLE
API-005: カテゴリ一覧（GET /api/categories）

### DIFF
--- a/web/app/api/categories/route.ts
+++ b/web/app/api/categories/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { assertHouseholdMember, getSession } from '@/server/utils/auth'
+import { normalizeError, toErrorBody } from '@/server/utils/errors'
+import { categoriesRepository } from '@/server/repositories/categoriesRepository'
+
+export async function GET(req: NextRequest) {
+  try {
+    const session = await getSession(req)
+    await assertHouseholdMember(session)
+
+    const list = await categoriesRepository.list(session.householdId!)
+    return NextResponse.json(list, { status: 200 })
+  } catch (e: unknown) {
+    const err = normalizeError(e)
+    return NextResponse.json(toErrorBody(err), { status: err.status })
+  }
+}
+

--- a/web/server/repositories/categoriesRepository.ts
+++ b/web/server/repositories/categoriesRepository.ts
@@ -1,0 +1,24 @@
+import { createSupabaseAdmin } from '@/server/clients/supabase'
+
+export type Category = {
+  id: string
+  name: string
+  type: 'income' | 'expense' | 'both'
+  sort_order: number
+}
+
+export const categoriesRepository = {
+  async list(householdId: string): Promise<Category[]> {
+    const supabase = createSupabaseAdmin()
+    const { data, error } = await supabase
+      .from('categories')
+      .select('id, name, type, sort_order')
+      .eq('household_id', householdId)
+      .order('sort_order', { ascending: true })
+      .order('name', { ascending: true })
+
+    if (error) throw error
+    return (data ?? []) as Category[]
+  },
+}
+

--- a/web/tests/api/categories_list.test.ts
+++ b/web/tests/api/categories_list.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+import * as route from '@/app/api/categories/route'
+
+vi.mock('@/server/utils/auth', () => ({
+  getSession: vi.fn(),
+  assertHouseholdMember: vi.fn(),
+}))
+
+vi.mock('@/server/repositories/categoriesRepository', () => ({
+  categoriesRepository: {
+    list: vi.fn(),
+  },
+}))
+
+import * as authModule from '@/server/utils/auth'
+import type { Session } from '@/server/utils/auth'
+import * as repoModule from '@/server/repositories/categoriesRepository'
+import type { Category } from '@/server/repositories/categoriesRepository'
+import { unauthorized, forbidden } from '@/server/utils/errors'
+
+function makeReq(headers: Record<string, string> = {}): NextRequest {
+  const h = new Headers(headers)
+  return { headers: h } as unknown as NextRequest
+}
+
+describe('GET /api/categories', () => {
+  const getSession = vi.mocked(authModule.getSession)
+  const assertHouseholdMember = vi.mocked(authModule.assertHouseholdMember)
+  const categoriesRepository = vi.mocked(repoModule.categoriesRepository)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 401 when unauthorized', async () => {
+    getSession.mockRejectedValue(unauthorized())
+    const req = makeReq()
+    const res = await route.GET(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 when household scope missing', async () => {
+    const session: Session = { userId: 'u-1', token: 't' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockRejectedValue(forbidden('household scope required'))
+    const req = makeReq()
+    const res = await route.GET(req)
+    expect(res.status).toBe(403)
+    const json = await res.json()
+    expect(json.code).toBe('FORBIDDEN')
+  })
+
+  it('returns 200 with categories list', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+    const list: Category[] = [
+      { id: 'c-1', name: 'Food', type: 'expense', sort_order: 1 },
+      { id: 'c-2', name: 'Salary', type: 'income', sort_order: 2 },
+    ]
+    categoriesRepository.list.mockResolvedValue(list)
+
+    const req = makeReq({ 'x-household-id': 'h-1' })
+    const res = await route.GET(req)
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual(list)
+    expect(categoriesRepository.list).toHaveBeenCalledWith('h-1')
+  })
+})
+


### PR DESCRIPTION
## 実装内容
- カテゴリ一覧API(GET /api/categories)のController/Repository実装
- householdスコープ必須化(assertHouseholdMember)
- Supabase経由で`household_id`スコープのカテゴリ取得
- 並び順: `sort_order` ASC, `name` ASC

## 参照設計書
- docs/design/detail/v1.0/feature/api_detail.md
- docs/design/base/v1.0/api.md

## テスト結果
- [x] 単体テスト: 通過（vitest 3ファイル・15テスト中、対象3テスト全て通過）
- [ ] 統合テスト: 未実施
- [ ] 手動テスト: 未実施

## 確認事項
- [x] コードレビュー対象
- [x] 設計書との整合性確認
- [ ] パフォーマンス確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added a Categories API endpoint (GET /api/categories) that returns the household’s category list in JSON, sorted by custom order then name.
  * Requires authentication and household membership; returns appropriate error responses when access is invalid.

* Tests
  * Added coverage for unauthorized (401), forbidden (403), and successful (200) responses, ensuring correct behavior and payloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->