### PR TITLE
API-006: カテゴリ登録（POST /api/categories）

### DIFF
--- a/web/app/api/categories/route.ts
+++ b/web/app/api/categories/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { assertHouseholdMember, getSession } from '@/server/utils/auth'
-import { normalizeError, toErrorBody } from '@/server/utils/errors'
+import { normalizeError, toErrorBody, badRequest } from '@/server/utils/errors'
 import { categoriesRepository } from '@/server/repositories/categoriesRepository'
+import { categoryCreateSchema } from '@/server/schemas/category'
 
 export async function GET(req: NextRequest) {
   try {
@@ -16,3 +17,22 @@ export async function GET(req: NextRequest) {
   }
 }
 
+export async function POST(req: NextRequest) {
+  try {
+    const session = await getSession(req)
+    await assertHouseholdMember(session)
+
+    const json = await req.json().catch(() => ({}))
+    const parsed = categoryCreateSchema.safeParse(json)
+    if (!parsed.success) {
+      const message = parsed.error.message
+      throw badRequest(message, parsed.error)
+    }
+
+    const created = await categoriesRepository.create(session.householdId!, parsed.data)
+    return NextResponse.json(created, { status: 201 })
+  } catch (e: unknown) {
+    const err = normalizeError(e)
+    return NextResponse.json(toErrorBody(err), { status: err.status })
+  }
+}

--- a/web/server/repositories/categoriesRepository.ts
+++ b/web/server/repositories/categoriesRepository.ts
@@ -20,5 +20,24 @@ export const categoriesRepository = {
     if (error) throw error
     return (data ?? []) as Category[]
   },
-}
+  async create(
+    householdId: string,
+    input: { name: string; type: Category['type']; sort_order: number },
+  ): Promise<Category> {
+    const supabase = createSupabaseAdmin()
+    const { data, error } = await supabase
+      .from('categories')
+      .insert({
+        household_id: householdId,
+        name: input.name,
+        type: input.type,
+        sort_order: input.sort_order,
+      })
+      .select('id, name, type, sort_order')
+      .single()
 
+    if (error) throw error
+    if (!data) throw new Error('Failed to create category')
+    return data as Category
+  },
+}

--- a/web/server/schemas/category.ts
+++ b/web/server/schemas/category.ts
@@ -1,0 +1,10 @@
+import { z } from 'zod'
+
+export const categoryCreateSchema = z.object({
+  name: z.string().min(1, 'name is required').max(100),
+  type: z.enum(['income', 'expense', 'both']),
+  sort_order: z.number().int().min(0).default(0),
+})
+
+export type CategoryCreateInput = z.infer<typeof categoryCreateSchema>
+

--- a/web/tests/api/categories_create.test.ts
+++ b/web/tests/api/categories_create.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+import * as route from '@/app/api/categories/route'
+
+vi.mock('@/server/utils/auth', () => ({
+  getSession: vi.fn(),
+  assertHouseholdMember: vi.fn(),
+}))
+
+vi.mock('@/server/repositories/categoriesRepository', () => ({
+  categoriesRepository: {
+    create: vi.fn(),
+  },
+}))
+
+import * as authModule from '@/server/utils/auth'
+import type { Session } from '@/server/utils/auth'
+import * as repoModule from '@/server/repositories/categoriesRepository'
+import type { Category } from '@/server/repositories/categoriesRepository'
+import { unauthorized, forbidden } from '@/server/utils/errors'
+
+function makeReq(body: unknown, headers: Record<string, string> = {}): NextRequest {
+  const h = new Headers(headers)
+  return {
+    headers: h,
+    json: async () => body,
+  } as unknown as NextRequest
+}
+
+describe('POST /api/categories', () => {
+  const getSession = vi.mocked(authModule.getSession)
+  const assertHouseholdMember = vi.mocked(authModule.assertHouseholdMember)
+  const categoriesRepository = vi.mocked(repoModule.categoriesRepository)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 400 when body is invalid', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+
+    const req = makeReq({})
+    const res = await route.POST(req)
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('returns 401 when unauthorized', async () => {
+    getSession.mockRejectedValue(unauthorized())
+
+    const req = makeReq({ name: 'Food', type: 'expense', sort_order: 1 })
+    const res = await route.POST(req)
+    expect(res.status).toBe(401)
+    const json = await res.json()
+    expect(json.code).toBe('UNAUTHORIZED')
+  })
+
+  it('returns 403 when household scope missing', async () => {
+    const session: Session = { userId: 'u-1', token: 't' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockRejectedValue(forbidden('household scope required'))
+
+    const req = makeReq({ name: 'Food', type: 'expense', sort_order: 1 })
+    const res = await route.POST(req)
+    expect(res.status).toBe(403)
+    const json = await res.json()
+    expect(json.code).toBe('FORBIDDEN')
+  })
+
+  it('creates category and returns 201', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+
+    const cat: Category = { id: 'c-1', name: 'Food', type: 'expense', sort_order: 1 }
+    categoriesRepository.create.mockResolvedValue(cat)
+
+    const req = makeReq({ name: 'Food', type: 'expense', sort_order: 1 }, { 'x-household-id': 'h-1' })
+    const res = await route.POST(req)
+    expect(res.status).toBe(201)
+    const json = await res.json()
+    expect(json).toEqual(cat)
+    expect(categoriesRepository.create).toHaveBeenCalledWith('h-1', {
+      name: 'Food',
+      type: 'expense',
+      sort_order: 1,
+    })
+  })
+})
+


### PR DESCRIPTION
## 実装内容
- カテゴリ登録APIの実装（POST /api/categories）
- Controller/Service（Repository）/Validationを追加
- 単体テストを追加（400/401/403/201の主要ケース）

## 参照設計書
- docs/design/detail/v1.0/feature/api_detail.md
- docs/design/base/v1.0/api.md

## テスト結果
- [x] 単体テスト: 通過
- [ ] 統合テスト: 未実施
- [ ] 手動テスト: 未実施

## 確認事項
- [x] コードレビュー対象
- [x] 設計書との整合性確認
- [ ] パフォーマンス確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added endpoint to create categories with validated input (name, type, sort order) and returns the created category.
  * Enforces authentication and household scope, with clear error responses for invalid input (400), unauthorized (401), and forbidden (403).

* Tests
  * Added comprehensive tests covering success and error cases for the categories creation endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->