### PR TITLE
API-007: カテゴリ更新（PATCH /api/categories/:id）

### DIFF
--- a/web/app/api/categories/[id]/route.ts
+++ b/web/app/api/categories/[id]/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { assertHouseholdMember, getSession } from '@/server/utils/auth'
+import { normalizeError, toErrorBody, badRequest } from '@/server/utils/errors'
+import { categoriesRepository } from '@/server/repositories/categoriesRepository'
+import { categoryUpdateSchema } from '@/server/schemas/category'
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: { id: string } },
+) {
+  try {
+    const session = await getSession(req)
+    await assertHouseholdMember(session)
+
+    const json = await req.json().catch(() => ({}))
+    const parsed = categoryUpdateSchema.safeParse(json)
+    if (!parsed.success) {
+      const message = parsed.error.message
+      throw badRequest(message, parsed.error)
+    }
+
+    const updated = await categoriesRepository.update(
+      session.householdId!,
+      params.id,
+      parsed.data,
+    )
+    return NextResponse.json(updated, { status: 200 })
+  } catch (e: unknown) {
+    const err = normalizeError(e)
+    return NextResponse.json(toErrorBody(err), { status: err.status })
+  }
+}
+

--- a/web/app/api/categories/[id]/route.ts
+++ b/web/app/api/categories/[id]/route.ts
@@ -6,7 +6,7 @@ import { categoryUpdateSchema } from '@/server/schemas/category'
 
 export async function PATCH(
   req: NextRequest,
-  { params }: { params: { id: string } },
+  { params }: { params: Promise<{ id: string }> },
 ) {
   try {
     const session = await getSession(req)
@@ -19,9 +19,10 @@ export async function PATCH(
       throw badRequest(message, parsed.error)
     }
 
+    const { id } = await params
     const updated = await categoriesRepository.update(
       session.householdId!,
-      params.id,
+      id,
       parsed.data,
     )
     return NextResponse.json(updated, { status: 200 })

--- a/web/server/repositories/categoriesRepository.ts
+++ b/web/server/repositories/categoriesRepository.ts
@@ -40,4 +40,22 @@ export const categoriesRepository = {
     if (!data) throw new Error('Failed to create category')
     return data as Category
   },
+  async update(
+    householdId: string,
+    id: string,
+    input: Partial<{ name: string; type: Category['type']; sort_order: number }>,
+  ): Promise<Category> {
+    const supabase = createSupabaseAdmin()
+    const { data, error } = await supabase
+      .from('categories')
+      .update(input)
+      .eq('household_id', householdId)
+      .eq('id', id)
+      .select('id, name, type, sort_order')
+      .single()
+
+    if (error) throw error
+    if (!data) throw new Error('Category not found')
+    return data as Category
+  },
 }

--- a/web/server/schemas/category.ts
+++ b/web/server/schemas/category.ts
@@ -8,3 +8,5 @@ export const categoryCreateSchema = z.object({
 
 export type CategoryCreateInput = z.infer<typeof categoryCreateSchema>
 
+export const categoryUpdateSchema = categoryCreateSchema.partial()
+export type CategoryUpdateInput = z.infer<typeof categoryUpdateSchema>

--- a/web/tests/api/categories_update.test.ts
+++ b/web/tests/api/categories_update.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+import * as route from '@/app/api/categories/[id]/route'
+
+vi.mock('@/server/utils/auth', () => ({
+  getSession: vi.fn(),
+  assertHouseholdMember: vi.fn(),
+}))
+
+vi.mock('@/server/repositories/categoriesRepository', () => ({
+  categoriesRepository: {
+    update: vi.fn(),
+  },
+}))
+
+import * as authModule from '@/server/utils/auth'
+import type { Session } from '@/server/utils/auth'
+import * as repoModule from '@/server/repositories/categoriesRepository'
+import type { Category } from '@/server/repositories/categoriesRepository'
+import { unauthorized, forbidden } from '@/server/utils/errors'
+
+function makeReq(body: unknown, headers: Record<string, string> = {}): NextRequest {
+  const h = new Headers(headers)
+  return {
+    headers: h,
+    json: async () => body,
+  } as unknown as NextRequest
+}
+
+describe('PATCH /api/categories/:id', () => {
+  const getSession = vi.mocked(authModule.getSession)
+  const assertHouseholdMember = vi.mocked(authModule.assertHouseholdMember)
+  const categoriesRepository = vi.mocked(repoModule.categoriesRepository)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 400 when body is invalid', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+
+    // invalid type
+    const req = makeReq({ type: 'invalid' })
+    const res = await route.PATCH(req, { params: { id: 'c-1' } })
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('returns 401 when unauthorized', async () => {
+    getSession.mockRejectedValue(unauthorized())
+
+    const req = makeReq({ name: 'Groceries' })
+    const res = await route.PATCH(req, { params: { id: 'c-1' } })
+    expect(res.status).toBe(401)
+    const json = await res.json()
+    expect(json.code).toBe('UNAUTHORIZED')
+  })
+
+  it('returns 403 when household scope missing', async () => {
+    const session: Session = { userId: 'u-1', token: 't' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockRejectedValue(forbidden('household scope required'))
+
+    const req = makeReq({ name: 'Groceries' })
+    const res = await route.PATCH(req, { params: { id: 'c-1' } })
+    expect(res.status).toBe(403)
+    const json = await res.json()
+    expect(json.code).toBe('FORBIDDEN')
+  })
+
+  it('updates category and returns 200', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+
+    const cat: Category = { id: 'c-1', name: 'Groceries', type: 'expense', sort_order: 2 }
+    categoriesRepository.update.mockResolvedValue(cat)
+
+    const req = makeReq({ name: 'Groceries', sort_order: 2 }, { 'x-household-id': 'h-1' })
+    const res = await route.PATCH(req, { params: { id: 'c-1' } })
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual(cat)
+    expect(categoriesRepository.update).toHaveBeenCalledWith('h-1', 'c-1', {
+      name: 'Groceries',
+      sort_order: 2,
+    })
+  })
+})
+

--- a/web/tests/api/categories_update.test.ts
+++ b/web/tests/api/categories_update.test.ts
@@ -48,7 +48,7 @@ describe('PATCH /api/categories/:id', () => {
 
     // invalid type
     const req = makeReq({ type: 'invalid' })
-    const res = await route.PATCH(req, { params: { id: 'c-1' } })
+    const res = await route.PATCH(req, { params: Promise.resolve({ id: 'c-1' }) })
     expect(res.status).toBe(400)
     const json = await res.json()
     expect(json.code).toBe('VALIDATION_ERROR')
@@ -58,7 +58,7 @@ describe('PATCH /api/categories/:id', () => {
     getSession.mockRejectedValue(unauthorized())
 
     const req = makeReq({ name: 'Groceries' })
-    const res = await route.PATCH(req, { params: { id: 'c-1' } })
+    const res = await route.PATCH(req, { params: Promise.resolve({ id: 'c-1' }) })
     expect(res.status).toBe(401)
     const json = await res.json()
     expect(json.code).toBe('UNAUTHORIZED')
@@ -70,7 +70,7 @@ describe('PATCH /api/categories/:id', () => {
     assertHouseholdMember.mockRejectedValue(forbidden('household scope required'))
 
     const req = makeReq({ name: 'Groceries' })
-    const res = await route.PATCH(req, { params: { id: 'c-1' } })
+    const res = await route.PATCH(req, { params: Promise.resolve({ id: 'c-1' }) })
     expect(res.status).toBe(403)
     const json = await res.json()
     expect(json.code).toBe('FORBIDDEN')
@@ -85,7 +85,7 @@ describe('PATCH /api/categories/:id', () => {
     categoriesRepository.update.mockResolvedValue(cat)
 
     const req = makeReq({ name: 'Groceries', sort_order: 2 }, { 'x-household-id': 'h-1' })
-    const res = await route.PATCH(req, { params: { id: 'c-1' } })
+    const res = await route.PATCH(req, { params: Promise.resolve({ id: 'c-1' }) })
     expect(res.status).toBe(200)
     const json = await res.json()
     expect(json).toEqual(cat)


### PR DESCRIPTION
## 実装内容
- カテゴリ更新エンドポイントを追加: PATCH /api/categories/:id
- Repositoryにupdate実装を追加（household_id+idで更新）
- Zodスキーマ: categoryUpdateSchema（部分更新）
- 単体テスト: 正常/未認証/権限不足/バリデーションエラー

## 参照設計書
- docs/design/detail/v1.0/feature/api_detail.md
- docs/tasks/v1.0.md（API-007）

## テスト結果
- [x] 単体テスト: 通過
- [ ] 統合テスト: なし
- [ ] 手動テスト: 未

## 確認事項
- [x] コードレビュー対象
- [x] 設計書との整合性確認
- [ ] パフォーマンス確認



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added endpoint to update a category by ID, enabling edits to name, type, and sort order.
  - Returns updated category on success and standardized error responses on failure.
  - Enforces authentication and household membership.

- Bug Fixes
  - Improved input validation with clear 400 responses for invalid data.

- Tests
  - Added comprehensive tests for update behavior, including success, validation errors (400), unauthorized access (401), and forbidden scope (403).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->