### PR TITLE
API-008: アカウント一覧（GET /api/accounts）

### DIFF
--- a/docs/tasks/v1.0.md
+++ b/docs/tasks/v1.0.md
@@ -210,8 +210,8 @@
 - **説明**: 自世帯アカウントの一覧取得
 - **参照先**: docs/design/detail/v1.0/feature/api_detail.md
 - **成果物**: 
-  - [ ] Controller/Repository
-  - [ ] 単体テスト
+  - [x] Controller/Repository
+  - [x] 単体テスト
 - **推定工数**: 0.5日
 - **依存タスク**: API-000, DB-001
 

--- a/web/app/api/accounts/route.ts
+++ b/web/app/api/accounts/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { assertHouseholdMember, getSession } from '@/server/utils/auth'
+import { normalizeError, toErrorBody } from '@/server/utils/errors'
+import { accountsRepository } from '@/server/repositories/accountsRepository'
+
+export async function GET(req: NextRequest) {
+  try {
+    const session = await getSession(req)
+    await assertHouseholdMember(session)
+
+    const list = await accountsRepository.list(session.householdId!)
+    return NextResponse.json(list, { status: 200 })
+  } catch (e: unknown) {
+    const err = normalizeError(e)
+    return NextResponse.json(toErrorBody(err), { status: err.status })
+  }
+}
+

--- a/web/server/repositories/accountsRepository.ts
+++ b/web/server/repositories/accountsRepository.ts
@@ -1,0 +1,24 @@
+import { createSupabaseAdmin } from '@/server/clients/supabase'
+
+export type Account = {
+  id: string
+  name: string
+  type: 'cash' | 'bank' | 'card' | 'other'
+  sort_order: number
+}
+
+export const accountsRepository = {
+  async list(householdId: string): Promise<Account[]> {
+    const supabase = createSupabaseAdmin()
+    const { data, error } = await supabase
+      .from('accounts')
+      .select('id, name, type, sort_order')
+      .eq('household_id', householdId)
+      .order('sort_order', { ascending: true })
+      .order('name', { ascending: true })
+
+    if (error) throw error
+    return (data ?? []) as Account[]
+  },
+}
+

--- a/web/tests/api/accounts_list.test.ts
+++ b/web/tests/api/accounts_list.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+import * as route from '@/app/api/accounts/route'
+
+vi.mock('@/server/utils/auth', () => ({
+  getSession: vi.fn(),
+  assertHouseholdMember: vi.fn(),
+}))
+
+vi.mock('@/server/repositories/accountsRepository', () => ({
+  accountsRepository: {
+    list: vi.fn(),
+  },
+}))
+
+import * as authModule from '@/server/utils/auth'
+import type { Session } from '@/server/utils/auth'
+import * as repoModule from '@/server/repositories/accountsRepository'
+import type { Account } from '@/server/repositories/accountsRepository'
+import { unauthorized, forbidden } from '@/server/utils/errors'
+
+function makeReq(headers: Record<string, string> = {}): NextRequest {
+  const h = new Headers(headers)
+  return { headers: h } as unknown as NextRequest
+}
+
+describe('GET /api/accounts', () => {
+  const getSession = vi.mocked(authModule.getSession)
+  const assertHouseholdMember = vi.mocked(authModule.assertHouseholdMember)
+  const accountsRepository = vi.mocked(repoModule.accountsRepository)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 401 when unauthorized', async () => {
+    getSession.mockRejectedValue(unauthorized())
+    const req = makeReq()
+    // @ts-expect-error -- route handler signature
+    const res = await route.GET(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 when household scope missing', async () => {
+    const session: Session = { userId: 'u-1', token: 't' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockRejectedValue(forbidden('household scope required'))
+    const req = makeReq()
+    // @ts-expect-error -- route handler signature
+    const res = await route.GET(req)
+    expect(res.status).toBe(403)
+    const json = await res.json()
+    expect(json.code).toBe('FORBIDDEN')
+  })
+
+  it('returns 200 with accounts list', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+    const list: Account[] = [
+      { id: 'a-1', name: 'Cash', type: 'cash', sort_order: 1 },
+      { id: 'a-2', name: 'Main Bank', type: 'bank', sort_order: 2 },
+    ]
+    accountsRepository.list.mockResolvedValue(list)
+
+    const req = makeReq({ 'x-household-id': 'h-1' })
+    // @ts-expect-error -- route handler signature
+    const res = await route.GET(req)
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual(list)
+    expect(accountsRepository.list).toHaveBeenCalledWith('h-1')
+  })
+})
+

--- a/web/tests/api/accounts_list.test.ts
+++ b/web/tests/api/accounts_list.test.ts
@@ -41,7 +41,6 @@ describe('GET /api/accounts', () => {
   it('returns 401 when unauthorized', async () => {
     getSession.mockRejectedValue(unauthorized())
     const req = makeReq()
-    // @ts-expect-error -- route handler signature
     const res = await route.GET(req)
     expect(res.status).toBe(401)
   })
@@ -51,7 +50,6 @@ describe('GET /api/accounts', () => {
     getSession.mockResolvedValue(session)
     assertHouseholdMember.mockRejectedValue(forbidden('household scope required'))
     const req = makeReq()
-    // @ts-expect-error -- route handler signature
     const res = await route.GET(req)
     expect(res.status).toBe(403)
     const json = await res.json()
@@ -69,7 +67,6 @@ describe('GET /api/accounts', () => {
     accountsRepository.list.mockResolvedValue(list)
 
     const req = makeReq({ 'x-household-id': 'h-1' })
-    // @ts-expect-error -- route handler signature
     const res = await route.GET(req)
     expect(res.status).toBe(200)
     const json = await res.json()


### PR DESCRIPTION
## 実装内容
- アカウント一覧 API の実装（GET /api/accounts）
- Repository 実装（`accounts` テーブル: id/name/type/sort_order）
- Controller 実装（認証/RLSスコープ検証）
- 単体テスト（未認証/権限不足/正常系）

## 参照設計書
- docs/design/detail/v1.0/feature/api_detail.md
- docs/design/base/v1.0/database.md

## テスト結果
- [x] 単体テスト: 通過
- [ ] 統合テスト: 対象外
- [ ] 手動テスト: 任意

## 確認事項
- [x] コードレビュー対象
- [x] 設計書との整合性確認
- [x] パフォーマンス確認（index利用: household_id, sort_order/name）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an Accounts API endpoint to retrieve a household’s accounts, enforcing authentication and household membership and returning results sorted consistently.
  - Returns standardized error responses with appropriate HTTP statuses.

- **Tests**
  - Added test coverage for the Accounts API covering unauthorized (401), forbidden (403), and successful (200) retrieval scenarios; verifies auth, authorization, and response payloads.

- **Documentation**
  - Updated task status to mark controller/repository and unit tests as completed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->