### PR TITLE
API-009: アカウント登録（POST /api/accounts）

### DIFF
--- a/web/app/api/accounts/route.ts
+++ b/web/app/api/accounts/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { assertHouseholdMember, getSession } from '@/server/utils/auth'
-import { normalizeError, toErrorBody } from '@/server/utils/errors'
+import { normalizeError, toErrorBody, badRequest } from '@/server/utils/errors'
 import { accountsRepository } from '@/server/repositories/accountsRepository'
+import { accountCreateSchema } from '@/server/schemas/account'
 
 export async function GET(req: NextRequest) {
   try {
@@ -10,6 +11,26 @@ export async function GET(req: NextRequest) {
 
     const list = await accountsRepository.list(session.householdId!)
     return NextResponse.json(list, { status: 200 })
+  } catch (e: unknown) {
+    const err = normalizeError(e)
+    return NextResponse.json(toErrorBody(err), { status: err.status })
+  }
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const session = await getSession(req)
+    await assertHouseholdMember(session)
+
+    const json = await req.json().catch(() => ({}))
+    const parsed = accountCreateSchema.safeParse(json)
+    if (!parsed.success) {
+      const message = parsed.error.message
+      throw badRequest(message, parsed.error)
+    }
+
+    const created = await accountsRepository.create(session.householdId!, parsed.data)
+    return NextResponse.json(created, { status: 201 })
   } catch (e: unknown) {
     const err = normalizeError(e)
     return NextResponse.json(toErrorBody(err), { status: err.status })

--- a/web/server/repositories/accountsRepository.ts
+++ b/web/server/repositories/accountsRepository.ts
@@ -20,5 +20,24 @@ export const accountsRepository = {
     if (error) throw error
     return (data ?? []) as Account[]
   },
-}
+  async create(
+    householdId: string,
+    input: { name: string; type: Account['type']; sort_order: number },
+  ): Promise<Account> {
+    const supabase = createSupabaseAdmin()
+    const { data, error } = await supabase
+      .from('accounts')
+      .insert({
+        household_id: householdId,
+        name: input.name,
+        type: input.type,
+        sort_order: input.sort_order,
+      })
+      .select('id, name, type, sort_order')
+      .single()
 
+    if (error) throw error
+    if (!data) throw new Error('Failed to create account')
+    return data as Account
+  },
+}

--- a/web/server/schemas/account.ts
+++ b/web/server/schemas/account.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod'
+
+export const accountCreateSchema = z.object({
+  name: z.string().min(1, 'name is required').max(100),
+  type: z.enum(['cash', 'bank', 'card', 'other']),
+  sort_order: z.number().int().min(0).default(0),
+})
+
+export type AccountCreateInput = z.infer<typeof accountCreateSchema>
+
+export const accountUpdateSchema = accountCreateSchema.partial()
+export type AccountUpdateInput = z.infer<typeof accountUpdateSchema>
+

--- a/web/tests/api/accounts_create.test.ts
+++ b/web/tests/api/accounts_create.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+import * as route from '@/app/api/accounts/route'
+
+vi.mock('@/server/utils/auth', () => ({
+  getSession: vi.fn(),
+  assertHouseholdMember: vi.fn(),
+}))
+
+vi.mock('@/server/repositories/accountsRepository', () => ({
+  accountsRepository: {
+    create: vi.fn(),
+  },
+}))
+
+import * as authModule from '@/server/utils/auth'
+import type { Session } from '@/server/utils/auth'
+import * as repoModule from '@/server/repositories/accountsRepository'
+import type { Account } from '@/server/repositories/accountsRepository'
+import { unauthorized, forbidden } from '@/server/utils/errors'
+
+function makeReq(body: unknown, headers: Record<string, string> = {}): NextRequest {
+  const h = new Headers(headers)
+  return {
+    headers: h,
+    json: async () => body,
+  } as unknown as NextRequest
+}
+
+describe('POST /api/accounts', () => {
+  const getSession = vi.mocked(authModule.getSession)
+  const assertHouseholdMember = vi.mocked(authModule.assertHouseholdMember)
+  const accountsRepository = vi.mocked(repoModule.accountsRepository)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 400 when body is invalid', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+
+    const req = makeReq({})
+    const res = await route.POST(req)
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('returns 401 when unauthorized', async () => {
+    getSession.mockRejectedValue(unauthorized())
+
+    const req = makeReq({ name: 'Wallet', type: 'cash', sort_order: 1 })
+    const res = await route.POST(req)
+    expect(res.status).toBe(401)
+    const json = await res.json()
+    expect(json.code).toBe('UNAUTHORIZED')
+  })
+
+  it('returns 403 when household scope missing', async () => {
+    const session: Session = { userId: 'u-1', token: 't' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockRejectedValue(forbidden('household scope required'))
+
+    const req = makeReq({ name: 'Wallet', type: 'cash', sort_order: 1 })
+    const res = await route.POST(req)
+    expect(res.status).toBe(403)
+    const json = await res.json()
+    expect(json.code).toBe('FORBIDDEN')
+  })
+
+  it('creates account and returns 201', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+
+    const acc: Account = { id: 'a-1', name: 'Wallet', type: 'cash', sort_order: 1 }
+    accountsRepository.create.mockResolvedValue(acc)
+
+    const req = makeReq({ name: 'Wallet', type: 'cash', sort_order: 1 }, { 'x-household-id': 'h-1' })
+    const res = await route.POST(req)
+    expect(res.status).toBe(201)
+    const json = await res.json()
+    expect(json).toEqual(acc)
+    expect(accountsRepository.create).toHaveBeenCalledWith('h-1', {
+      name: 'Wallet',
+      type: 'cash',
+      sort_order: 1,
+    })
+  })
+})
+


### PR DESCRIPTION
## 実装内容
- POST `/api/accounts` のコントローラ実装
- `accountsRepository.create` 実装（Supabase SDK 経由で enmann DB を参照）
- 入力バリデーション（Zod）を `server/schemas/account.ts` に追加
- 単体テスト `web/tests/api/accounts_create.test.ts` 追加（正常/401/403/400）

## 参照設計書
- docs/design/detail/v1.0/feature/api_detail.md
- docs/design/base/v1.0/database.md

## テスト結果
- [x] 単体テスト: 通過
- [x] 統合テスト: N/A（このPRの範囲外）
- [x] 手動テスト: N/A（ローカルでの単体確認）

## 確認事項
- [x] コードレビュー対象
- [x] 設計書との整合性確認
- [x] パフォーマンス確認（単純INSERTのみ）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an endpoint to create accounts, returning the created record on success.
  - Validates input (name, type, sort order) with clear error messages for invalid requests.
  - Supports account types: cash, bank, card, and other; sort order defaults to 0.
  - Proper status codes: 201 on success, 400 for validation errors, 401/403 for auth issues.

- Tests
  - Added comprehensive tests covering success, validation failures, and authorization scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->