### PR TITLE
API-010: アカウント更新（PATCH /api/accounts/:id）

### DIFF
--- a/web/app/api/accounts/[id]/route.ts
+++ b/web/app/api/accounts/[id]/route.ts
@@ -1,10 +1,13 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { assertHouseholdMember, getSession } from '@/server/utils/auth'
-import { badRequest, normalizeError, toErrorBody } from '@/server/utils/errors'
+import { normalizeError, toErrorBody, badRequest } from '@/server/utils/errors'
 import { accountsRepository } from '@/server/repositories/accountsRepository'
 import { accountUpdateSchema } from '@/server/schemas/account'
 
-export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
   try {
     const session = await getSession(req)
     await assertHouseholdMember(session)
@@ -16,7 +19,12 @@ export async function PATCH(req: NextRequest, { params }: { params: { id: string
       throw badRequest(message, parsed.error)
     }
 
-    const updated = await accountsRepository.update(session.householdId!, params.id, parsed.data)
+    const { id } = await params
+    const updated = await accountsRepository.update(
+      session.householdId!,
+      id,
+      parsed.data,
+    )
     return NextResponse.json(updated, { status: 200 })
   } catch (e: unknown) {
     const err = normalizeError(e)

--- a/web/app/api/accounts/[id]/route.ts
+++ b/web/app/api/accounts/[id]/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { assertHouseholdMember, getSession } from '@/server/utils/auth'
+import { badRequest, normalizeError, toErrorBody } from '@/server/utils/errors'
+import { accountsRepository } from '@/server/repositories/accountsRepository'
+import { accountUpdateSchema } from '@/server/schemas/account'
+
+export async function PATCH(req: NextRequest, { params }: { params: { id: string } }) {
+  try {
+    const session = await getSession(req)
+    await assertHouseholdMember(session)
+
+    const json = await req.json().catch(() => ({}))
+    const parsed = accountUpdateSchema.safeParse(json)
+    if (!parsed.success) {
+      const message = parsed.error.message
+      throw badRequest(message, parsed.error)
+    }
+
+    const updated = await accountsRepository.update(session.householdId!, params.id, parsed.data)
+    return NextResponse.json(updated, { status: 200 })
+  } catch (e: unknown) {
+    const err = normalizeError(e)
+    return NextResponse.json(toErrorBody(err), { status: err.status })
+  }
+}
+

--- a/web/server/repositories/accountsRepository.ts
+++ b/web/server/repositories/accountsRepository.ts
@@ -20,5 +20,22 @@ export const accountsRepository = {
     if (error) throw error
     return (data ?? []) as Account[]
   },
-}
+  async update(
+    householdId: string,
+    id: string,
+    input: Partial<{ name: string; type: Account['type']; sort_order: number }>,
+  ): Promise<Account> {
+    const supabase = createSupabaseAdmin()
+    const { data, error } = await supabase
+      .from('accounts')
+      .update(input)
+      .eq('household_id', householdId)
+      .eq('id', id)
+      .select('id, name, type, sort_order')
+      .single()
 
+    if (error) throw error
+    if (!data) throw new Error('Account not found')
+    return data as Account
+  },
+}

--- a/web/server/schemas/account.ts
+++ b/web/server/schemas/account.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod'
+
+export const accountCreateSchema = z.object({
+  name: z.string().min(1, 'name is required').max(100),
+  type: z.enum(['cash', 'bank', 'card', 'other']),
+  sort_order: z.number().int().min(0).default(0),
+})
+
+export type AccountCreateInput = z.infer<typeof accountCreateSchema>
+
+export const accountUpdateSchema = accountCreateSchema.partial()
+export type AccountUpdateInput = z.infer<typeof accountUpdateSchema>
+

--- a/web/tests/api/accounts_update.test.ts
+++ b/web/tests/api/accounts_update.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+import * as route from '@/app/api/accounts/[id]/route'
+
+vi.mock('@/server/utils/auth', () => ({
+  getSession: vi.fn(),
+  assertHouseholdMember: vi.fn(),
+}))
+
+vi.mock('@/server/repositories/accountsRepository', () => ({
+  accountsRepository: {
+    update: vi.fn(),
+  },
+}))
+
+import * as authModule from '@/server/utils/auth'
+import type { Session } from '@/server/utils/auth'
+import * as repoModule from '@/server/repositories/accountsRepository'
+import type { Account } from '@/server/repositories/accountsRepository'
+import { unauthorized, forbidden } from '@/server/utils/errors'
+
+function makeReq(method: string, body?: unknown, headers: Record<string, string> = {}): NextRequest {
+  const h = new Headers(headers)
+  const reqInit: any = { method, headers: h }
+  if (body !== undefined) {
+    const json = JSON.stringify(body)
+    reqInit.json = async () => JSON.parse(json)
+  } else {
+    reqInit.json = async () => { throw new Error('no body') }
+  }
+  return reqInit as unknown as NextRequest
+}
+
+describe('PATCH /api/accounts/:id', () => {
+  const getSession = vi.mocked(authModule.getSession)
+  const assertHouseholdMember = vi.mocked(authModule.assertHouseholdMember)
+  const accountsRepository = vi.mocked(repoModule.accountsRepository)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 401 when unauthorized', async () => {
+    getSession.mockRejectedValue(unauthorized())
+    const req = makeReq('PATCH')
+    const res = await route.PATCH(req, { params: { id: 'a-1' } })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 when household scope missing', async () => {
+    const session: Session = { userId: 'u-1', token: 't' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockRejectedValue(forbidden('household scope required'))
+    const req = makeReq('PATCH', { name: 'New Name' })
+    const res = await route.PATCH(req, { params: { id: 'a-1' } })
+    expect(res.status).toBe(403)
+    const json = await res.json()
+    expect(json.code).toBe('FORBIDDEN')
+  })
+
+  it('returns 400 when body invalid', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+    // invalid type value
+    const req = makeReq('PATCH', { type: 'invalid' })
+    const res = await route.PATCH(req, { params: { id: 'a-1' } })
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 200 with updated account', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+
+    const updated: Account = { id: 'a-1', name: 'Wallet', type: 'cash', sort_order: 3 }
+    accountsRepository.update.mockResolvedValue(updated)
+
+    const req = makeReq('PATCH', { name: 'Wallet', sort_order: 3 }, { 'x-household-id': 'h-1' })
+    const res = await route.PATCH(req, { params: { id: 'a-1' } })
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual(updated)
+    expect(accountsRepository.update).toHaveBeenCalledWith('h-1', 'a-1', { name: 'Wallet', sort_order: 3 })
+  })
+})
+

--- a/web/tests/api/accounts_update.test.ts
+++ b/web/tests/api/accounts_update.test.ts
@@ -20,16 +20,12 @@ import * as repoModule from '@/server/repositories/accountsRepository'
 import type { Account } from '@/server/repositories/accountsRepository'
 import { unauthorized, forbidden } from '@/server/utils/errors'
 
-function makeReq(method: string, body?: unknown, headers: Record<string, string> = {}): NextRequest {
+function makeReq(body: unknown, headers: Record<string, string> = {}): NextRequest {
   const h = new Headers(headers)
-  const reqInit: any = { method, headers: h }
-  if (body !== undefined) {
-    const json = JSON.stringify(body)
-    reqInit.json = async () => JSON.parse(json)
-  } else {
-    reqInit.json = async () => { throw new Error('no body') }
-  }
-  return reqInit as unknown as NextRequest
+  return {
+    headers: h,
+    json: async () => body,
+  } as unknown as NextRequest
 }
 
 describe('PATCH /api/accounts/:id', () => {
@@ -45,48 +41,58 @@ describe('PATCH /api/accounts/:id', () => {
     vi.restoreAllMocks()
   })
 
+  it('returns 400 when body is invalid', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+
+    // invalid type
+    const req = makeReq({ type: 'invalid' })
+    const res = await route.PATCH(req, { params: Promise.resolve({ id: 'a-1' }) })
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.code).toBe('VALIDATION_ERROR')
+  })
+
   it('returns 401 when unauthorized', async () => {
     getSession.mockRejectedValue(unauthorized())
-    const req = makeReq('PATCH')
-    const res = await route.PATCH(req, { params: { id: 'a-1' } })
+
+    const req = makeReq({ name: 'Wallet' })
+    const res = await route.PATCH(req, { params: Promise.resolve({ id: 'a-1' }) })
     expect(res.status).toBe(401)
+    const json = await res.json()
+    expect(json.code).toBe('UNAUTHORIZED')
   })
 
   it('returns 403 when household scope missing', async () => {
     const session: Session = { userId: 'u-1', token: 't' }
     getSession.mockResolvedValue(session)
     assertHouseholdMember.mockRejectedValue(forbidden('household scope required'))
-    const req = makeReq('PATCH', { name: 'New Name' })
-    const res = await route.PATCH(req, { params: { id: 'a-1' } })
+
+    const req = makeReq({ name: 'Wallet' })
+    const res = await route.PATCH(req, { params: Promise.resolve({ id: 'a-1' }) })
     expect(res.status).toBe(403)
     const json = await res.json()
     expect(json.code).toBe('FORBIDDEN')
   })
 
-  it('returns 400 when body invalid', async () => {
-    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
-    getSession.mockResolvedValue(session)
-    assertHouseholdMember.mockResolvedValue()
-    // invalid type value
-    const req = makeReq('PATCH', { type: 'invalid' })
-    const res = await route.PATCH(req, { params: { id: 'a-1' } })
-    expect(res.status).toBe(400)
-  })
-
-  it('returns 200 with updated account', async () => {
+  it('updates account and returns 200', async () => {
     const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
     getSession.mockResolvedValue(session)
     assertHouseholdMember.mockResolvedValue()
 
-    const updated: Account = { id: 'a-1', name: 'Wallet', type: 'cash', sort_order: 3 }
-    accountsRepository.update.mockResolvedValue(updated)
+    const acc: Account = { id: 'a-1', name: 'Wallet', type: 'cash', sort_order: 2 }
+    accountsRepository.update.mockResolvedValue(acc)
 
-    const req = makeReq('PATCH', { name: 'Wallet', sort_order: 3 }, { 'x-household-id': 'h-1' })
-    const res = await route.PATCH(req, { params: { id: 'a-1' } })
+    const req = makeReq({ name: 'Wallet', sort_order: 2 }, { 'x-household-id': 'h-1' })
+    const res = await route.PATCH(req, { params: Promise.resolve({ id: 'a-1' }) })
     expect(res.status).toBe(200)
     const json = await res.json()
-    expect(json).toEqual(updated)
-    expect(accountsRepository.update).toHaveBeenCalledWith('h-1', 'a-1', { name: 'Wallet', sort_order: 3 })
+    expect(json).toEqual(acc)
+    expect(accountsRepository.update).toHaveBeenCalledWith('h-1', 'a-1', {
+      name: 'Wallet',
+      sort_order: 2,
+    })
   })
 })
 


### PR DESCRIPTION
## 実装内容
- アカウント更新 API `PATCH /api/accounts/:id` を追加
- `accountsRepository.update` を実装（`household_id` + `id` で更新制限）
- バリデーション（Zod）を追加：`web/server/schemas/account.ts`
- 単体テストを追加：`web/tests/api/accounts_update.test.ts`

## 参照設計書
- docs/design/detail/v1.0/feature/api_detail.md
- docs/design/base/v1.0/api.md

## テスト結果
- [x] 単体テスト: 通過（Vitest）
- [x] 統合テスト: N/A（本PR対象外）
- [x] 手動テスト: N/A（ユニットで担保）

## 確認事項
- [x] コードレビュー対象
- [x] 設計書との整合性確認
- [x] パフォーマンス確認（単純UPDATEのみ）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced PATCH /api/accounts/:id to update account details (name, type, sort order).
  * Enforces authentication and household membership with consistent, descriptive error responses.
  * Validates request data and returns updated account on success.

* **Tests**
  * Added coverage for invalid payload (400), unauthorized (401), forbidden (403), and successful update (200) scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->