### PR TITLE
API-011: 取引一覧（GET /api/transactions?month|date）

### DIFF
--- a/web/app/api/transactions/route.ts
+++ b/web/app/api/transactions/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { assertHouseholdMember, getSession } from '@/server/utils/auth'
+import { normalizeError, toErrorBody, badRequest } from '@/server/utils/errors'
+import { transactionsRepository } from '@/server/repositories/transactionsRepository'
+
+function isMonth(v: string) {
+  return /^\d{4}-\d{2}$/.test(v)
+}
+
+function isDate(v: string) {
+  return /^\d{4}-\d{2}-\d{2}$/.test(v)
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const session = await getSession(req)
+    await assertHouseholdMember(session)
+
+    const url = new URL(req.url)
+    const month = url.searchParams.get('month') || undefined
+    const date = url.searchParams.get('date') || undefined
+    const kindParam = url.searchParams.get('kind') || undefined
+    const kind = kindParam === 'income' || kindParam === 'expense' ? kindParam : undefined
+
+    if (!month && !date) {
+      throw badRequest('month or date is required')
+    }
+    if (month && !isMonth(month)) {
+      throw badRequest('month must be YYYY-MM')
+    }
+    if (date && !isDate(date)) {
+      throw badRequest('date must be YYYY-MM-DD')
+    }
+
+    let list
+    if (date) {
+      list = await transactionsRepository.listByDate(session.householdId!, date, kind)
+    } else {
+      list = await transactionsRepository.listByMonth(session.householdId!, month!, kind)
+    }
+    return NextResponse.json(list, { status: 200 })
+  } catch (e: unknown) {
+    const err = normalizeError(e)
+    return NextResponse.json(toErrorBody(err), { status: err.status })
+  }
+}
+

--- a/web/server/repositories/transactionsRepository.ts
+++ b/web/server/repositories/transactionsRepository.ts
@@ -1,0 +1,71 @@
+import { createSupabaseAdmin } from '@/server/clients/supabase'
+
+export type Transaction = {
+  id: string
+  kind: 'income' | 'expense'
+  occurred_on: string
+  amount: number
+  category_id: string
+  account_id: string
+  place?: string | null
+  memo?: string | null
+}
+
+export const transactionsRepository = {
+  async listByMonth(
+    householdId: string,
+    month: string, // YYYY-MM
+    kind?: 'income' | 'expense',
+  ): Promise<Transaction[]> {
+    const supabase = createSupabaseAdmin()
+
+    // Build date range [firstDay, firstDayNextMonth)
+    const firstDay = `${month}-01`
+    // Compute next month string safely
+    const [y, m] = month.split('-').map((v) => parseInt(v, 10))
+    const nextMonthDate = new Date(Date.UTC(y, m, 1)) // month is 0-based in JS Date, so using m (already +1) yields next month first day
+    const nextMonth = `${nextMonthDate.getUTCFullYear()}-${String(nextMonthDate.getUTCMonth() + 1).padStart(2, '0')}`
+    const nextFirstDay = `${nextMonth}-01`
+
+    let query = supabase
+      .from('transactions')
+      .select(
+        'id, kind, occurred_on, amount, category_id, account_id, place, memo',
+      )
+      .eq('household_id', householdId)
+      .gte('occurred_on', firstDay)
+      .lt('occurred_on', nextFirstDay)
+      .order('occurred_on', { ascending: true })
+      .order('created_at', { ascending: true })
+
+    if (kind) query = query.eq('kind', kind)
+
+    const { data, error } = await query
+    if (error) throw error
+    return (data ?? []) as Transaction[]
+  },
+
+  async listByDate(
+    householdId: string,
+    date: string, // YYYY-MM-DD
+    kind?: 'income' | 'expense',
+  ): Promise<Transaction[]> {
+    const supabase = createSupabaseAdmin()
+
+    let query = supabase
+      .from('transactions')
+      .select(
+        'id, kind, occurred_on, amount, category_id, account_id, place, memo',
+      )
+      .eq('household_id', householdId)
+      .eq('occurred_on', date)
+      .order('created_at', { ascending: true })
+
+    if (kind) query = query.eq('kind', kind)
+
+    const { data, error } = await query
+    if (error) throw error
+    return (data ?? []) as Transaction[]
+  },
+}
+

--- a/web/tests/api/transactions_list.test.ts
+++ b/web/tests/api/transactions_list.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+import * as route from '@/app/api/transactions/route'
+
+vi.mock('@/server/utils/auth', () => ({
+  getSession: vi.fn(),
+  assertHouseholdMember: vi.fn(),
+}))
+
+vi.mock('@/server/repositories/transactionsRepository', () => ({
+  transactionsRepository: {
+    listByMonth: vi.fn(),
+    listByDate: vi.fn(),
+  },
+}))
+
+import * as authModule from '@/server/utils/auth'
+import type { Session } from '@/server/utils/auth'
+import * as repoModule from '@/server/repositories/transactionsRepository'
+import type { Transaction } from '@/server/repositories/transactionsRepository'
+import { unauthorized, forbidden } from '@/server/utils/errors'
+
+function makeReq(url: string, headers: Record<string, string> = {}): NextRequest {
+  const h = new Headers(headers)
+  return { headers: h, url } as unknown as NextRequest
+}
+
+describe('GET /api/transactions', () => {
+  const getSession = vi.mocked(authModule.getSession)
+  const assertHouseholdMember = vi.mocked(authModule.assertHouseholdMember)
+  const transactionsRepository = vi.mocked(repoModule.transactionsRepository)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 401 when unauthorized', async () => {
+    getSession.mockRejectedValue(unauthorized())
+    const req = makeReq('http://test.local/api/transactions')
+    const res = await route.GET(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 when household scope missing', async () => {
+    const session: Session = { userId: 'u-1', token: 't' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockRejectedValue(forbidden('household scope required'))
+    const req = makeReq('http://test.local/api/transactions')
+    const res = await route.GET(req)
+    expect(res.status).toBe(403)
+    const json = await res.json()
+    expect(json.code).toBe('FORBIDDEN')
+  })
+
+  it('validates month/date presence', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+    const req = makeReq('http://test.local/api/transactions')
+    const res = await route.GET(req)
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('returns 200 with list by month', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+    const list: Transaction[] = [
+      {
+        id: 't-1',
+        kind: 'expense',
+        occurred_on: '2025-09-01',
+        amount: 1200,
+        category_id: 'c-1',
+        account_id: 'a-1',
+        place: 'スーパー',
+        memo: '夕飯',
+      },
+    ]
+    transactionsRepository.listByMonth.mockResolvedValue(list)
+
+    const req = makeReq('http://test.local/api/transactions?month=2025-09&kind=expense', {
+      'x-household-id': 'h-1',
+    })
+    const res = await route.GET(req)
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual(list)
+    expect(transactionsRepository.listByMonth).toHaveBeenCalledWith('h-1', '2025-09', 'expense')
+  })
+
+  it('returns 200 with list by date', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+    const list: Transaction[] = []
+    transactionsRepository.listByDate.mockResolvedValue(list)
+
+    const req = makeReq('http://test.local/api/transactions?date=2025-09-02')
+    const res = await route.GET(req)
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual([])
+    expect(transactionsRepository.listByDate).toHaveBeenCalledWith('h-1', '2025-09-02', undefined)
+  })
+})
+


### PR DESCRIPTION
## 実装内容
- /api/transactions (GET) を実装（`month` または `date` クエリでフィルタ、任意で `kind`）
- Repository: `transactionsRepository.listByMonth` / `listByDate` を追加（Supabaseでenmann DB参照）
- バリデーション: `month`=YYYY-MM or `date`=YYYY-MM-DD（未指定時は400）
- エラーハンドリング: 共通のnormalizeErrorを使用
- 単体テスト: `web/tests/api/transactions_list.test.ts` を追加

## 参照設計書
- docs/design/detail/v1.0/feature/api_detail.md
- docs/design/base/v1.0/database.md

## テスト結果
- [x] 単体テスト: 通過（Vitest）
- [ ] 統合テスト: 未実施
- [ ] 手動テスト: 未実施

## 確認事項
- [ ] コードレビュー対象
- [ ] 設計書との整合性確認
- [ ] パフォーマンス確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added an authenticated API endpoint to retrieve household transactions with flexible filters: by month (YYYY-MM) or exact date (YYYY-MM-DD), and by type (income or expense). Returns properly sorted results.

- Tests
  - Introduced comprehensive tests covering authorization, permission checks, input validation, and successful retrieval for both monthly and daily queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->