### PR TITLE
API-012: 取引登録（POST /api/transactions）

### DIFF
--- a/web/app/api/transactions/route.ts
+++ b/web/app/api/transactions/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server'
 import { assertHouseholdMember, getSession } from '@/server/utils/auth'
 import { normalizeError, toErrorBody, badRequest } from '@/server/utils/errors'
 import { transactionsRepository } from '@/server/repositories/transactionsRepository'
+import { txCreateSchema } from '@/server/schemas/transaction'
 
 function isMonth(v: string) {
   return /^\d{4}-\d{2}$/.test(v)
@@ -45,3 +46,25 @@ export async function GET(req: NextRequest) {
   }
 }
 
+export async function POST(req: NextRequest) {
+  try {
+    const session = await getSession(req)
+    await assertHouseholdMember(session)
+
+    const json = await req.json().catch(() => ({}))
+    const parsed = txCreateSchema.safeParse(json)
+    if (!parsed.success) {
+      const message = parsed.error.message
+      throw badRequest(message, parsed.error)
+    }
+
+    const created = await transactionsRepository.create(
+      session.householdId!,
+      parsed.data,
+    )
+    return NextResponse.json(created, { status: 201 })
+  } catch (e: unknown) {
+    const err = normalizeError(e)
+    return NextResponse.json(toErrorBody(err), { status: err.status })
+  }
+}

--- a/web/server/repositories/transactionsRepository.ts
+++ b/web/server/repositories/transactionsRepository.ts
@@ -12,6 +12,30 @@ export type Transaction = {
 }
 
 export const transactionsRepository = {
+  async create(
+    householdId: string,
+    input: import('@/server/schemas/transaction').TxCreateInput,
+  ): Promise<Transaction> {
+    const supabase = createSupabaseAdmin()
+    const { data, error } = await supabase
+      .from('transactions')
+      .insert({
+        household_id: householdId,
+        kind: input.kind,
+        occurred_on: input.occurred_on,
+        amount: input.amount,
+        category_id: input.category_id,
+        account_id: input.account_id,
+        place: input.place ?? null,
+        memo: input.memo ?? null,
+      })
+      .select('id, kind, occurred_on, amount, category_id, account_id, place, memo')
+      .single()
+
+    if (error) throw error
+    if (!data) throw new Error('Failed to create transaction')
+    return data as Transaction
+  },
   async listByMonth(
     householdId: string,
     month: string, // YYYY-MM

--- a/web/tests/api/transactions_create.test.ts
+++ b/web/tests/api/transactions_create.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+import * as route from '@/app/api/transactions/route'
+
+vi.mock('@/server/utils/auth', () => ({
+  getSession: vi.fn(),
+  assertHouseholdMember: vi.fn(),
+}))
+
+vi.mock('@/server/repositories/transactionsRepository', () => ({
+  transactionsRepository: {
+    create: vi.fn(),
+  },
+}))
+
+import * as authModule from '@/server/utils/auth'
+import type { Session } from '@/server/utils/auth'
+import * as repoModule from '@/server/repositories/transactionsRepository'
+import type { Transaction } from '@/server/repositories/transactionsRepository'
+import { unauthorized, forbidden } from '@/server/utils/errors'
+import { txCreateSchema } from '@/server/schemas/transaction'
+
+function makeReq(body: unknown, headers: Record<string, string> = {}): NextRequest {
+  const h = new Headers(headers)
+  return {
+    headers: h,
+    json: async () => body,
+  } as unknown as NextRequest
+}
+
+describe('POST /api/transactions', () => {
+  const getSession = vi.mocked(authModule.getSession)
+  const assertHouseholdMember = vi.mocked(authModule.assertHouseholdMember)
+  const transactionsRepository = vi.mocked(repoModule.transactionsRepository)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 400 when body is invalid', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+
+    const req = makeReq({})
+    const res = await route.POST(req)
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('returns 401 when unauthorized', async () => {
+    getSession.mockRejectedValue(unauthorized())
+
+    const req = makeReq({
+      kind: 'expense',
+      occurred_on: '2025-09-02',
+      amount: 1200,
+      category_id: '11111111-1111-1111-1111-111111111111',
+      account_id: '22222222-2222-2222-2222-222222222222',
+      place: 'スーパー',
+      memo: '夕飯',
+    })
+    const res = await route.POST(req)
+    expect(res.status).toBe(401)
+    const json = await res.json()
+    expect(json.code).toBe('UNAUTHORIZED')
+  })
+
+  it('returns 403 when household scope missing', async () => {
+    const session: Session = { userId: 'u-1', token: 't' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockRejectedValue(forbidden('household scope required'))
+
+    const req = makeReq({
+      kind: 'expense',
+      occurred_on: '2025-09-02',
+      amount: 1200,
+      category_id: '11111111-1111-1111-1111-111111111111',
+      account_id: '22222222-2222-2222-2222-222222222222',
+    })
+    const res = await route.POST(req)
+    expect(res.status).toBe(403)
+    const json = await res.json()
+    expect(json.code).toBe('FORBIDDEN')
+  })
+
+  it('creates transaction and returns 201', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+
+    const tx: Transaction = {
+      id: 't-1',
+      kind: 'expense',
+      occurred_on: '2025-09-02',
+      amount: 1200,
+      category_id: '11111111-1111-1111-8aaa-111111111111',
+      account_id: '22222222-2222-2222-8bbb-222222222222',
+      place: 'スーパー',
+      memo: '夕飯',
+    }
+    transactionsRepository.create.mockResolvedValue(tx)
+
+    const input = {
+      kind: 'expense',
+      occurred_on: '2025-09-02',
+      amount: 1200,
+      category_id: '11111111-1111-1111-8aaa-111111111111',
+      account_id: '22222222-2222-2222-8bbb-222222222222',
+      place: 'スーパー',
+      memo: '夕飯',
+    }
+    const req = makeReq(input, { 'x-household-id': 'h-1' })
+    const res = await route.POST(req)
+    expect(res.status).toBe(201)
+    const json = await res.json()
+    expect(json).toEqual(tx)
+    expect(transactionsRepository.create).toHaveBeenCalledWith('h-1', input)
+  })
+
+  it('accepts valid payload via schema', () => {
+    const input = {
+      kind: 'expense',
+      occurred_on: '2025-09-02',
+      amount: 1200,
+      category_id: '11111111-1111-1111-8aaa-111111111111',
+      account_id: '22222222-2222-2222-8bbb-222222222222',
+      place: 'スーパー',
+      memo: '夕飯',
+    }
+    const parsed = txCreateSchema.safeParse(input)
+    if (!parsed.success) {
+      // Debug output for schema issues
+      // eslint-disable-next-line no-console
+      console.log(parsed.error.issues)
+    }
+    expect(parsed.success).toBe(true)
+  })
+})


### PR DESCRIPTION
## 実装内容
- POST `/api/transactions` の実装（Controller/Repository）
- `txCreateSchema` によるバリデーション（kind/occurred_on/amount/category_id/account_id 等）
- `transactionsRepository.create` 追加（Supabase/MCP 経由で挿入）
- 単体テスト追加：`tests/api/transactions_create.test.ts`

## 参照設計書
- docs/design/detail/v1.0/feature/backend_detail.md
- docs/design/detail/v1.0/feature/api_detail.md

## テスト結果
- [x] 単体テスト: 通過（Vitest 44 tests）
- [ ] 統合テスト: 対象外
- [ ] 手動テスト: 任意

## 確認事項
- [x] コードレビュー対象
- [x] 設計書との整合性確認
- [ ] パフォーマンス確認（挿入系は軽微）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a POST endpoint to the transactions API, allowing creation of transactions.
  * Returns the created transaction with a 201 status on success.
  * Includes input validation and standardized error responses (e.g., 400 for invalid input).

* **Tests**
  * Added comprehensive tests for the new endpoint covering validation errors, unauthorized/forbidden access, and successful creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->