### PR TITLE
API-013: 取引更新（PATCH /api/transactions/:id）

### DIFF
--- a/web/app/api/transactions/[id]/route.ts
+++ b/web/app/api/transactions/[id]/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { assertHouseholdMember, getSession } from '@/server/utils/auth'
+import { normalizeError, toErrorBody, badRequest } from '@/server/utils/errors'
+import { transactionsRepository } from '@/server/repositories/transactionsRepository'
+import { txUpdateSchema } from '@/server/schemas/transaction'
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const session = await getSession(req)
+    await assertHouseholdMember(session)
+
+    const json = await req.json().catch(() => ({}))
+    const parsed = txUpdateSchema.safeParse(json)
+    if (!parsed.success) {
+      const message = parsed.error.message
+      throw badRequest(message, parsed.error)
+    }
+
+    const { id } = await params
+    const updated = await transactionsRepository.update(
+      session.householdId!,
+      id,
+      parsed.data,
+    )
+    return NextResponse.json(updated, { status: 200 })
+  } catch (e: unknown) {
+    const err = normalizeError(e)
+    return NextResponse.json(toErrorBody(err), { status: err.status })
+  }
+}
+

--- a/web/server/repositories/transactionsRepository.ts
+++ b/web/server/repositories/transactionsRepository.ts
@@ -12,6 +12,26 @@ export type Transaction = {
 }
 
 export const transactionsRepository = {
+  async update(
+    householdId: string,
+    id: string,
+    input: import('@/server/schemas/transaction').TxUpdateInput,
+  ): Promise<Transaction> {
+    const supabase = createSupabaseAdmin()
+    const { data, error } = await supabase
+      .from('transactions')
+      .update(input as Record<string, unknown>)
+      .eq('household_id', householdId)
+      .eq('id', id)
+      .select(
+        'id, kind, occurred_on, amount, category_id, account_id, place, memo',
+      )
+      .single()
+
+    if (error) throw error
+    if (!data) throw new Error('Transaction not found')
+    return data as Transaction
+  },
   async create(
     householdId: string,
     input: import('@/server/schemas/transaction').TxCreateInput,

--- a/web/tests/api/transactions_update.test.ts
+++ b/web/tests/api/transactions_update.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+import * as route from '@/app/api/transactions/[id]/route'
+
+vi.mock('@/server/utils/auth', () => ({
+  getSession: vi.fn(),
+  assertHouseholdMember: vi.fn(),
+}))
+
+vi.mock('@/server/repositories/transactionsRepository', () => ({
+  transactionsRepository: {
+    update: vi.fn(),
+  },
+}))
+
+import * as authModule from '@/server/utils/auth'
+import type { Session } from '@/server/utils/auth'
+import * as repoModule from '@/server/repositories/transactionsRepository'
+import type { Transaction } from '@/server/repositories/transactionsRepository'
+import { unauthorized, forbidden } from '@/server/utils/errors'
+
+function makeReq(body: unknown, headers: Record<string, string> = {}): NextRequest {
+  const h = new Headers(headers)
+  return {
+    headers: h,
+    json: async () => body,
+  } as unknown as NextRequest
+}
+
+describe('PATCH /api/transactions/:id', () => {
+  const getSession = vi.mocked(authModule.getSession)
+  const assertHouseholdMember = vi.mocked(authModule.assertHouseholdMember)
+  const transactionsRepository = vi.mocked(repoModule.transactionsRepository)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 400 when body is invalid', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+
+    // invalid kind
+    const req = makeReq({ kind: 'invalid' })
+    const res = await route.PATCH(req, { params: Promise.resolve({ id: 't-1' }) })
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('returns 401 when unauthorized', async () => {
+    getSession.mockRejectedValue(unauthorized())
+
+    const req = makeReq({ amount: 3000 })
+    const res = await route.PATCH(req, { params: Promise.resolve({ id: 't-1' }) })
+    expect(res.status).toBe(401)
+    const json = await res.json()
+    expect(json.code).toBe('UNAUTHORIZED')
+  })
+
+  it('returns 403 when household scope missing', async () => {
+    const session: Session = { userId: 'u-1', token: 't' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockRejectedValue(forbidden('household scope required'))
+
+    const req = makeReq({ amount: 3000 })
+    const res = await route.PATCH(req, { params: Promise.resolve({ id: 't-1' }) })
+    expect(res.status).toBe(403)
+    const json = await res.json()
+    expect(json.code).toBe('FORBIDDEN')
+  })
+
+  it('updates transaction and returns 200', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+
+    const tx: Transaction = {
+      id: 't-1',
+      kind: 'expense',
+      occurred_on: '2025-09-01',
+      amount: 3000,
+      category_id: 'c-1',
+      account_id: 'a-1',
+      place: 'Store',
+      memo: 'updated memo',
+    }
+    transactionsRepository.update.mockResolvedValue(tx)
+
+    const req = makeReq({ amount: 3000, memo: 'updated memo' }, { 'x-household-id': 'h-1' })
+    const res = await route.PATCH(req, { params: Promise.resolve({ id: 't-1' }) })
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual(tx)
+    expect(transactionsRepository.update).toHaveBeenCalledWith('h-1', 't-1', {
+      amount: 3000,
+      memo: 'updated memo',
+    })
+  })
+})
+


### PR DESCRIPTION
## 実装内容
- 取引更新API（PATCH `/api/transactions/:id`）のController実装
- `transactionsRepository.update` の追加（householdスコープ + 単一取得）
- リクエストバリデーション（`txUpdateSchema`）
- 単体テスト追加：`web/tests/api/transactions_update.test.ts`

## 参照設計書
- docs/design/detail/v1.0/feature/api_detail.md
- docs/design/base/v1.0/api.md

## テスト結果
- [x] 単体テスト: 通過
- [ ] 統合テスト: N/A（今回範囲外）
- [ ] 手動テスト: N/A（今回範囲外）

## 確認事項
- [x] コードレビュー対象
- [x] 設計書との整合性確認
- [ ] パフォーマンス確認（必要に応じて）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - You can now update existing transactions via PATCH /api/transactions/:id.
  - Supports modifying key fields (e.g., amount, memo, category, account, date, type, place).
  - Returns clear validation errors for invalid updates.
  - Enforces authentication and household membership for secure updates.
- Tests
  - Added comprehensive tests covering successful updates and error scenarios (validation, unauthorized, forbidden), ensuring reliable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->