### PR TITLE
API-014: 取引削除（DELETE /api/transactions/:id）

### DIFF
--- a/web/app/api/transactions/[id]/route.ts
+++ b/web/app/api/transactions/[id]/route.ts
@@ -32,3 +32,19 @@ export async function PATCH(
   }
 }
 
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const session = await getSession(req)
+    await assertHouseholdMember(session)
+
+    const { id } = await params
+    await transactionsRepository.remove(session.householdId!, id)
+    return new NextResponse(null, { status: 204 })
+  } catch (e: unknown) {
+    const err = normalizeError(e)
+    return NextResponse.json(toErrorBody(err), { status: err.status })
+  }
+}

--- a/web/server/repositories/transactionsRepository.ts
+++ b/web/server/repositories/transactionsRepository.ts
@@ -12,6 +12,22 @@ export type Transaction = {
 }
 
 export const transactionsRepository = {
+  async remove(
+    householdId: string,
+    id: string,
+  ): Promise<void> {
+    const supabase = createSupabaseAdmin()
+    const { data, error } = await supabase
+      .from('transactions')
+      .delete()
+      .eq('household_id', householdId)
+      .eq('id', id)
+      .select('id')
+      .single()
+
+    if (error) throw error
+    if (!data) throw new Error('Transaction not found')
+  },
   async update(
     householdId: string,
     id: string,

--- a/web/tests/api/transactions_delete.test.ts
+++ b/web/tests/api/transactions_delete.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+import * as route from '@/app/api/transactions/[id]/route'
+
+vi.mock('@/server/utils/auth', () => ({
+  getSession: vi.fn(),
+  assertHouseholdMember: vi.fn(),
+}))
+
+vi.mock('@/server/repositories/transactionsRepository', () => ({
+  transactionsRepository: {
+    remove: vi.fn(),
+  },
+}))
+
+import * as authModule from '@/server/utils/auth'
+import type { Session } from '@/server/utils/auth'
+import * as repoModule from '@/server/repositories/transactionsRepository'
+import { unauthorized, forbidden } from '@/server/utils/errors'
+
+function makeReq(headers: Record<string, string> = {}): NextRequest {
+  const h = new Headers(headers)
+  return {
+    headers: h,
+  } as unknown as NextRequest
+}
+
+describe('DELETE /api/transactions/:id', () => {
+  const getSession = vi.mocked(authModule.getSession)
+  const assertHouseholdMember = vi.mocked(authModule.assertHouseholdMember)
+  const transactionsRepository = vi.mocked(repoModule.transactionsRepository)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 401 when unauthorized', async () => {
+    getSession.mockRejectedValue(unauthorized())
+
+    const req = makeReq()
+    const res = await route.DELETE(req, { params: Promise.resolve({ id: 't-1' }) })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 when household scope missing', async () => {
+    const session: Session = { userId: 'u-1', token: 't' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockRejectedValue(forbidden('household scope required'))
+
+    const req = makeReq()
+    const res = await route.DELETE(req, { params: Promise.resolve({ id: 't-1' }) })
+    expect(res.status).toBe(403)
+    const json = await res.json()
+    expect(json.code).toBe('FORBIDDEN')
+  })
+
+  it('deletes transaction and returns 204', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+    transactionsRepository.remove.mockResolvedValue(undefined)
+
+    const req = makeReq({ 'x-household-id': 'h-1' })
+    const res = await route.DELETE(req, { params: Promise.resolve({ id: 't-1' }) })
+    expect(res.status).toBe(204)
+    expect(transactionsRepository.remove).toHaveBeenCalledWith('h-1', 't-1')
+  })
+})
+


### PR DESCRIPTION
## 実装内容
- 取引削除APIを実装（DELETE /api/transactions/:id）
- Repositoryに `transactionsRepository.remove` を追加し、household_id と id で削除
- 単体テスト `web/tests/api/transactions_delete.test.ts` を追加（401/403/204を検証）

## 参照設計書
- docs/design/detail/v1.0/feature/api_detail.md
- docs/design/base/v1.0/api.md

## テスト結果
- [x] 単体テスト: 通過
- [x] 統合テスト: N/A（該当なし）
- [x] 手動テスト: N/A（モック中心）

## 確認事項
- [x] コードレビュー対象
- [x] 設計書との整合性確認
- [ ] パフォーマンス確認（RLS下での削除だが影響軽微）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a DELETE endpoint for transactions (/api/transactions/:id), allowing users to remove a transaction. Returns 204 No Content on success and meaningful error responses for unauthorized or forbidden access.

- Tests
  - Introduced comprehensive tests for the new DELETE endpoint, covering:
    - 401 when not authenticated
    - 403 when lacking required access
    - 204 on successful deletion, ensuring correct parameters are used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->