### PR TITLE
API-015: コメント一覧（GET /api/comments?transaction_id）

### DIFF
--- a/web/app/api/comments/route.ts
+++ b/web/app/api/comments/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { assertHouseholdMember, getSession } from '@/server/utils/auth'
+import { normalizeError, toErrorBody, badRequest } from '@/server/utils/errors'
+import { commentsRepository } from '@/server/repositories/commentsRepository'
+
+export async function GET(req: NextRequest) {
+  try {
+    const session = await getSession(req)
+    await assertHouseholdMember(session)
+
+    const url = new URL(req.url)
+    const transactionId = url.searchParams.get('transaction_id') || undefined
+
+    if (!transactionId) {
+      throw badRequest('transaction_id is required')
+    }
+
+    const list = await commentsRepository.listByTransaction(
+      session.householdId!,
+      transactionId,
+    )
+    return NextResponse.json(list, { status: 200 })
+  } catch (e: unknown) {
+    const err = normalizeError(e)
+    return NextResponse.json(toErrorBody(err), { status: err.status })
+  }
+}
+

--- a/web/server/repositories/commentsRepository.ts
+++ b/web/server/repositories/commentsRepository.ts
@@ -1,0 +1,28 @@
+import { createSupabaseAdmin } from '@/server/clients/supabase'
+
+export type Comment = {
+  id: string
+  transaction_id: string
+  body: string
+  created_by: string
+  created_at: string
+}
+
+export const commentsRepository = {
+  async listByTransaction(
+    householdId: string,
+    transactionId: string,
+  ): Promise<Comment[]> {
+    const supabase = createSupabaseAdmin()
+    const { data, error } = await supabase
+      .from('comments')
+      .select('id, transaction_id, body, created_by, created_at')
+      .eq('household_id', householdId)
+      .eq('transaction_id', transactionId)
+      .order('created_at', { ascending: true })
+
+    if (error) throw error
+    return (data ?? []) as Comment[]
+  },
+}
+

--- a/web/tests/api/comments_list.test.ts
+++ b/web/tests/api/comments_list.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+import * as route from '@/app/api/comments/route'
+
+vi.mock('@/server/utils/auth', () => ({
+  getSession: vi.fn(),
+  assertHouseholdMember: vi.fn(),
+}))
+
+vi.mock('@/server/repositories/commentsRepository', () => ({
+  commentsRepository: {
+    listByTransaction: vi.fn(),
+  },
+}))
+
+import * as authModule from '@/server/utils/auth'
+import type { Session } from '@/server/utils/auth'
+import * as repoModule from '@/server/repositories/commentsRepository'
+import type { Comment } from '@/server/repositories/commentsRepository'
+import { unauthorized, forbidden } from '@/server/utils/errors'
+
+function makeReq(url: string, headers: Record<string, string> = {}): NextRequest {
+  const h = new Headers(headers)
+  return { headers: h, url } as unknown as NextRequest
+}
+
+describe('GET /api/comments', () => {
+  const getSession = vi.mocked(authModule.getSession)
+  const assertHouseholdMember = vi.mocked(authModule.assertHouseholdMember)
+  const commentsRepository = vi.mocked(repoModule.commentsRepository)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 401 when unauthorized', async () => {
+    getSession.mockRejectedValue(unauthorized())
+    const req = makeReq('http://test.local/api/comments')
+    const res = await route.GET(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 when household scope missing', async () => {
+    const session: Session = { userId: 'u-1', token: 't' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockRejectedValue(forbidden('household scope required'))
+    const req = makeReq('http://test.local/api/comments')
+    const res = await route.GET(req)
+    expect(res.status).toBe(403)
+    const json = await res.json()
+    expect(json.code).toBe('FORBIDDEN')
+  })
+
+  it('validates transaction_id presence', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+    const req = makeReq('http://test.local/api/comments')
+    const res = await route.GET(req)
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('returns 200 with comments list', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+    const list: Comment[] = [
+      {
+        id: 'cm-1',
+        transaction_id: 'tx-1',
+        body: 'テストコメント',
+        created_by: 'u-1',
+        created_at: '2025-09-02T12:00:00Z',
+      },
+    ]
+    commentsRepository.listByTransaction.mockResolvedValue(list)
+
+    const req = makeReq('http://test.local/api/comments?transaction_id=tx-1', {
+      'x-household-id': 'h-1',
+    })
+    const res = await route.GET(req)
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual(list)
+    expect(commentsRepository.listByTransaction).toHaveBeenCalledWith('h-1', 'tx-1')
+  })
+})
+


### PR DESCRIPTION
## 実装内容
- コメント一覧API（GET /api/comments?transaction_id）の実装
- Repository（commentsRepository）実装
- 単体テスト追加（認証/権限/バリデーション/正常系）

## 参照設計書
- docs/design/detail/v1.0/feature/api_detail.md
- docs/design/base/v1.0/api.md
- docs/design/base/v1.0/database.md

## テスト結果
- [x] 単体テスト: 通過
- [ ] 統合テスト: 未実施
- [ ] 手動テスト: 未実施

## 確認事項
- [ ] コードレビュー対象
- [ ] 設計書との整合性確認
- [ ] パフォーマンス確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a GET /api/comments endpoint to fetch comments for a given transaction (via transaction_id). Requires authentication and household access. Returns a JSON list in chronological order with standardized error responses (400, 401, 403).
* **Tests**
  * Introduced comprehensive tests covering unauthorized, forbidden, missing transaction_id validation, and successful retrieval scenarios, ensuring correct status codes and responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->