### PR TITLE
API-016: コメント登録（POST /api/comments）

### DIFF
--- a/web/app/api/comments/route.ts
+++ b/web/app/api/comments/route.ts
@@ -3,6 +3,7 @@ import { assertHouseholdMember, getSession } from '@/server/utils/auth'
 import { normalizeError, toErrorBody, badRequest } from '@/server/utils/errors'
 import { commentsRepository } from '@/server/repositories/commentsRepository'
 import { commentCreateSchema } from '@/server/schemas/comment'
+import { commentService } from '@/server/services/commentService'
 
 export async function GET(req: NextRequest) {
   try {
@@ -39,11 +40,7 @@ export async function POST(req: NextRequest) {
       throw badRequest(message, parsed.error)
     }
 
-    const created = await commentsRepository.create(
-      session.householdId!,
-      session.userId,
-      parsed.data,
-    )
+    const created = await commentService.create(parsed.data, session)
     return NextResponse.json(created, { status: 201 })
   } catch (e: unknown) {
     const err = normalizeError(e)

--- a/web/server/services/commentService.ts
+++ b/web/server/services/commentService.ts
@@ -1,0 +1,31 @@
+import { commentsRepository } from '@/server/repositories/commentsRepository'
+import type { Session } from '@/server/utils/auth'
+import { notificationService } from '@/server/services/notificationService'
+
+export const commentService = {
+  async create(
+    input: import('@/server/schemas/comment').CommentCreateInput,
+    session: Session,
+  ) {
+    const created = await commentsRepository.create(
+      session.householdId!,
+      session.userId,
+      input,
+    )
+
+    // Fire notifications to other household members (best-effort)
+    try {
+      await notificationService.notifyCommentCreated({
+        householdId: session.householdId!,
+        actorUserId: session.userId,
+        transactionId: created.transaction_id,
+        commentId: created.id,
+      })
+    } catch (_e) {
+      // Intentionally swallow notification errors to not fail main flow
+    }
+
+    return created
+  },
+}
+

--- a/web/server/services/notificationService.ts
+++ b/web/server/services/notificationService.ts
@@ -1,0 +1,56 @@
+import { createSupabaseAdmin } from '@/server/clients/supabase'
+
+type NotificationType = 'subscription_reminder' | 'comment' | 'reaction'
+
+export type NotificationPayload = Record<string, unknown>
+
+async function listHouseholdMemberIds(householdId: string): Promise<string[]> {
+  const supabase = createSupabaseAdmin()
+  const { data, error } = await supabase
+    .from('household_members')
+    .select('user_id')
+    .eq('household_id', householdId)
+
+  if (error) throw error
+  return (data ?? []).map((r) => r.user_id as string)
+}
+
+async function insertNotifications(
+  householdId: string,
+  userIds: string[],
+  type: NotificationType,
+  payload: NotificationPayload,
+) {
+  if (userIds.length === 0) return
+  const supabase = createSupabaseAdmin()
+  const rows = userIds.map((uid) => ({
+    household_id: householdId,
+    user_id: uid,
+    type,
+    payload,
+  }))
+  const { error } = await supabase.from('notifications').insert(rows)
+  if (error) throw error
+}
+
+export const notificationService = {
+  async notifyCommentCreated(params: {
+    householdId: string
+    actorUserId: string
+    transactionId: string
+    commentId: string
+  }) {
+    const members = await listHouseholdMemberIds(params.householdId)
+    const recipients = members.filter((id) => id !== params.actorUserId)
+    await insertNotifications(
+      params.householdId,
+      recipients,
+      'comment',
+      {
+        transaction_id: params.transactionId,
+        comment_id: params.commentId,
+      },
+    )
+  },
+}
+

--- a/web/tests/api/comments_create.test.ts
+++ b/web/tests/api/comments_create.test.ts
@@ -8,15 +8,15 @@ vi.mock('@/server/utils/auth', () => ({
   assertHouseholdMember: vi.fn(),
 }))
 
-vi.mock('@/server/repositories/commentsRepository', () => ({
-  commentsRepository: {
+vi.mock('@/server/services/commentService', () => ({
+  commentService: {
     create: vi.fn(),
   },
 }))
 
 import * as authModule from '@/server/utils/auth'
 import type { Session } from '@/server/utils/auth'
-import * as repoModule from '@/server/repositories/commentsRepository'
+import * as serviceModule from '@/server/services/commentService'
 import type { Comment } from '@/server/repositories/commentsRepository'
 import { unauthorized, forbidden } from '@/server/utils/errors'
 
@@ -37,7 +37,7 @@ function makeReq(
 describe('POST /api/comments', () => {
   const getSession = vi.mocked(authModule.getSession)
   const assertHouseholdMember = vi.mocked(authModule.assertHouseholdMember)
-  const commentsRepository = vi.mocked(repoModule.commentsRepository)
+  const commentService = vi.mocked(serviceModule.commentService)
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -87,7 +87,7 @@ describe('POST /api/comments', () => {
       created_by: 'u-1',
       created_at: '2025-09-02T12:00:00Z',
     }
-    commentsRepository.create.mockResolvedValue(created)
+    commentService.create.mockResolvedValue(created)
 
     const req = makeReq(
       'http://test.local/api/comments',
@@ -98,10 +98,13 @@ describe('POST /api/comments', () => {
     expect(res.status).toBe(201)
     const json = await res.json()
     expect(json).toEqual(created)
-    expect(commentsRepository.create).toHaveBeenCalledWith('h-1', 'u-1', {
-      transaction_id: 'tx-1',
-      body: 'テストコメント',
-    })
+    expect(commentService.create).toHaveBeenCalledWith(
+      {
+        transaction_id: 'tx-1',
+        body: 'テストコメント',
+      },
+      { userId: 'u-1', token: 't', householdId: 'h-1' },
+    )
   })
 })
 


### PR DESCRIPTION
## 実装内容
- コメント登録APIのサービス化（CommentService）
- 通知連動（NotificationService）を追加し、コメント作成時に同一世帯の他メンバーへ通知レコードを生成
- POST /api/comments をサービス委譲に変更
- 既存の単体テストをサービス利用に合わせて更新

## 参照設計書
- docs/design/detail/v1.0/feature/api_detail.md（Comments/Notifications）
- docs/design/detail/v1.0/feature/backend_detail.md（CommentService/NotificationService）
- docs/design/base/v1.0/database.md（notifications）

## テスト結果
- [x] 単体テスト: 通過（vitest 59/59）
- [ ] 統合テスト: 対象外
- [ ] 手動テスト: レビュー後に実施

## 確認事項
- [x] コードレビュー対象
- [x] 設計書との整合性確認
- [ ] パフォーマンス確認（通知挿入のバルク動作）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Household members now receive notifications when a new comment is added to a transaction. Comment creation still succeeds even if notification delivery fails.

* Refactor
  * Centralized comment creation in a service layer to handle session-based ownership and downstream actions.

* Tests
  * Updated tests to target the new service abstraction and adjusted call patterns to use session-aware inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->