### PR TITLE
API-017: コメント削除（DELETE /api/comments/:id）

### DIFF
--- a/web/app/api/comments/[id]/route.ts
+++ b/web/app/api/comments/[id]/route.ts
@@ -1,0 +1,22 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { assertHouseholdMember, getSession } from '@/server/utils/auth'
+import { normalizeError, toErrorBody } from '@/server/utils/errors'
+import { commentsRepository } from '@/server/repositories/commentsRepository'
+
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const session = await getSession(req)
+    await assertHouseholdMember(session)
+
+    const { id } = await params
+    await commentsRepository.remove(session.householdId!, id, session.userId)
+    return new NextResponse(null, { status: 204 })
+  } catch (e: unknown) {
+    const err = normalizeError(e)
+    return NextResponse.json(toErrorBody(err), { status: err.status })
+  }
+}
+

--- a/web/server/repositories/commentsRepository.ts
+++ b/web/server/repositories/commentsRepository.ts
@@ -46,4 +46,22 @@ export const commentsRepository = {
     if (!data) throw new Error('Failed to create comment')
     return data as Comment
   },
+  async remove(
+    householdId: string,
+    id: string,
+    userId: string,
+  ): Promise<void> {
+    const supabase = createSupabaseAdmin()
+    const { data, error } = await supabase
+      .from('comments')
+      .delete()
+      .eq('household_id', householdId)
+      .eq('id', id)
+      .eq('created_by', userId)
+      .select('id')
+      .single()
+
+    if (error) throw error
+    if (!data) throw new Error('Comment not found or not owned by user')
+  },
 }

--- a/web/tests/api/comments_delete.test.ts
+++ b/web/tests/api/comments_delete.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+import * as route from '@/app/api/comments/[id]/route'
+
+vi.mock('@/server/utils/auth', () => ({
+  getSession: vi.fn(),
+  assertHouseholdMember: vi.fn(),
+}))
+
+vi.mock('@/server/repositories/commentsRepository', () => ({
+  commentsRepository: {
+    remove: vi.fn(),
+  },
+}))
+
+import * as authModule from '@/server/utils/auth'
+import type { Session } from '@/server/utils/auth'
+import * as repoModule from '@/server/repositories/commentsRepository'
+import { unauthorized, forbidden } from '@/server/utils/errors'
+
+function makeReq(headers: Record<string, string> = {}): NextRequest {
+  const h = new Headers(headers)
+  return {
+    headers: h,
+  } as unknown as NextRequest
+}
+
+describe('DELETE /api/comments/:id', () => {
+  const getSession = vi.mocked(authModule.getSession)
+  const assertHouseholdMember = vi.mocked(authModule.assertHouseholdMember)
+  const commentsRepository = vi.mocked(repoModule.commentsRepository)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 401 when unauthorized', async () => {
+    getSession.mockRejectedValue(unauthorized())
+
+    const req = makeReq()
+    const res = await route.DELETE(req, { params: Promise.resolve({ id: 'cm-1' }) })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 when household scope missing', async () => {
+    const session: Session = { userId: 'u-1', token: 't' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockRejectedValue(forbidden('household scope required'))
+
+    const req = makeReq()
+    const res = await route.DELETE(req, { params: Promise.resolve({ id: 'cm-1' }) })
+    expect(res.status).toBe(403)
+    const json = await res.json()
+    expect(json.code).toBe('FORBIDDEN')
+  })
+
+  it('deletes comment and returns 204 (owner only)', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+    commentsRepository.remove.mockResolvedValue(undefined)
+
+    const req = makeReq({ 'x-household-id': 'h-1' })
+    const res = await route.DELETE(req, { params: Promise.resolve({ id: 'cm-1' }) })
+    expect(res.status).toBe(204)
+    expect(commentsRepository.remove).toHaveBeenCalledWith('h-1', 'cm-1', 'u-1')
+  })
+})
+


### PR DESCRIPTION
## 実装内容
- コメント削除エンドポイントを追加  (DELETE)
- リポジトリに  を実装（本人のみ削除可能）
- 単体テスト追加：

## 参照設計書
- docs/design/detail/v1.0/feature/api_detail.md

## テスト結果
- [x] 単体テスト: 通過
- [x] 統合テスト: 該当なし
- [x] 手動テスト: 未実施

## 確認事項
- [x] コードレビュー対象
- [x] 設計書との整合性確認
- [x] パフォーマンス確認（削除クエリの条件走査）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added DELETE endpoint for comments, enabling authenticated household members to delete their own comments. Returns 204 No Content on success and JSON errors with appropriate status codes on failure (unauthorized, forbidden, not found/not owner).

* Tests
  * Added tests covering unauthorized access, forbidden household scope, and successful deletion, ensuring correct authentication, authorization, and repository interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->