### PR TITLE
API-019: リアクション一覧（GET /api/reactions）

### DIFF
--- a/web/app/api/reactions/route.ts
+++ b/web/app/api/reactions/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { assertHouseholdMember, getSession } from '@/server/utils/auth'
+import { normalizeError, toErrorBody, badRequest } from '@/server/utils/errors'
+import { reactionsRepository } from '@/server/repositories/reactionsRepository'
+
+export async function GET(req: NextRequest) {
+  try {
+    const session = await getSession(req)
+    await assertHouseholdMember(session)
+
+    const url = new URL(req.url)
+    const transactionId = url.searchParams.get('transaction_id') || undefined
+
+    if (!transactionId) {
+      throw badRequest('transaction_id is required')
+    }
+
+    const list = await reactionsRepository.listByTransaction(
+      session.householdId!,
+      transactionId,
+    )
+    return NextResponse.json(list, { status: 200 })
+  } catch (e: unknown) {
+    const err = normalizeError(e)
+    return NextResponse.json(toErrorBody(err), { status: err.status })
+  }
+}
+

--- a/web/server/repositories/reactionsRepository.ts
+++ b/web/server/repositories/reactionsRepository.ts
@@ -10,6 +10,21 @@ export type Reaction = {
 }
 
 export const reactionsRepository = {
+  async listByTransaction(
+    householdId: string,
+    transactionId: string,
+  ): Promise<Reaction[]> {
+    const supabase = createSupabaseAdmin()
+    const { data, error } = await supabase
+      .from('reactions')
+      .select('id, transaction_id, emoji, user_id, created_at')
+      .eq('household_id', householdId)
+      .eq('transaction_id', transactionId)
+      .order('created_at', { ascending: true })
+
+    if (error) throw error
+    return (data ?? []) as Reaction[]
+  },
   async findByUserAndTransaction(
     householdId: string,
     transactionId: string,

--- a/web/tests/api/reactions_list.test.ts
+++ b/web/tests/api/reactions_list.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+import * as route from '@/app/api/reactions/route'
+
+vi.mock('@/server/utils/auth', () => ({
+  getSession: vi.fn(),
+  assertHouseholdMember: vi.fn(),
+}))
+
+vi.mock('@/server/repositories/reactionsRepository', () => ({
+  reactionsRepository: {
+    listByTransaction: vi.fn(),
+  },
+}))
+
+import * as authModule from '@/server/utils/auth'
+import type { Session } from '@/server/utils/auth'
+import * as repoModule from '@/server/repositories/reactionsRepository'
+import type { Reaction } from '@/server/repositories/reactionsRepository'
+import { unauthorized, forbidden } from '@/server/utils/errors'
+
+function makeReq(url: string, headers: Record<string, string> = {}): NextRequest {
+  const h = new Headers(headers)
+  return { headers: h, url } as unknown as NextRequest
+}
+
+describe('GET /api/reactions', () => {
+  const getSession = vi.mocked(authModule.getSession)
+  const assertHouseholdMember = vi.mocked(authModule.assertHouseholdMember)
+  const reactionsRepository = vi.mocked(repoModule.reactionsRepository)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 401 when unauthorized', async () => {
+    getSession.mockRejectedValue(unauthorized())
+    const req = makeReq('http://test.local/api/reactions')
+    const res = await route.GET(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 when household scope missing', async () => {
+    const session: Session = { userId: 'u-1', token: 't' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockRejectedValue(forbidden('household scope required'))
+    const req = makeReq('http://test.local/api/reactions')
+    const res = await route.GET(req)
+    expect(res.status).toBe(403)
+    const json = await res.json()
+    expect(json.code).toBe('FORBIDDEN')
+  })
+
+  it('validates transaction_id presence', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+    const req = makeReq('http://test.local/api/reactions')
+    const res = await route.GET(req)
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('returns 200 with reactions list', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+    const list: Reaction[] = [
+      {
+        id: 'rc-1',
+        transaction_id: 'tx-1',
+        emoji: '👍',
+        user_id: 'u-1',
+        created_at: '2025-09-02T12:00:00Z',
+      },
+    ]
+    reactionsRepository.listByTransaction.mockResolvedValue(list)
+
+    const req = makeReq('http://test.local/api/reactions?transaction_id=tx-1', {
+      'x-household-id': 'h-1',
+    })
+    const res = await route.GET(req)
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual(list)
+    expect(reactionsRepository.listByTransaction).toHaveBeenCalledWith('h-1', 'tx-1')
+  })
+})
+


### PR DESCRIPTION
## 実装内容
- リアクション一覧APIの実装（GET `/api/reactions?transaction_id=`）
- `reactionsRepository.listByTransaction` を追加
- 単体テスト `web/tests/api/reactions_list.test.ts` を追加し全件通過

## 参照設計書
- docs/design/detail/v1.0/feature/api_detail.md

## テスト結果
- [x] 単体テスト: 通過
- [x] 統合テスト: 通過（該当範囲）
- [x] 手動テスト: 確認（最小限）

## 確認事項
- [x] コードレビュー対象
- [x] 設計書との整合性確認
- [x] パフォーマンス確認（インデックス設計に沿ったクエリ）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now view emoji reactions associated with a specific transaction. The app retrieves reactions for the current household and returns them in chronological order, with clear error messages for missing or invalid inputs.
* **Tests**
  * Added comprehensive tests for the reactions retrieval endpoint, covering authorization, household access checks, input validation, and successful responses to ensure reliable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->