### PR TITLE
API-020: サブスク一覧（GET /api/subscriptions）

### DIFF
--- a/web/app/api/subscriptions/route.ts
+++ b/web/app/api/subscriptions/route.ts
@@ -1,0 +1,18 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { assertHouseholdMember, getSession } from '@/server/utils/auth'
+import { normalizeError, toErrorBody } from '@/server/utils/errors'
+import { subscriptionsRepository } from '@/server/repositories/subscriptionsRepository'
+
+export async function GET(req: NextRequest) {
+  try {
+    const session = await getSession(req)
+    await assertHouseholdMember(session)
+
+    const list = await subscriptionsRepository.list(session.householdId!)
+    return NextResponse.json(list, { status: 200 })
+  } catch (e: unknown) {
+    const err = normalizeError(e)
+    return NextResponse.json(toErrorBody(err), { status: err.status })
+  }
+}
+

--- a/web/server/repositories/subscriptionsRepository.ts
+++ b/web/server/repositories/subscriptionsRepository.ts
@@ -1,0 +1,27 @@
+import { createSupabaseAdmin } from '@/server/clients/supabase'
+
+export type Subscription = {
+  id: string
+  name: string
+  expected_amount: number
+  category_id: string
+  account_id: string
+  billing_day: number
+  note: string | null
+}
+
+export const subscriptionsRepository = {
+  async list(householdId: string): Promise<Subscription[]> {
+    const supabase = createSupabaseAdmin()
+    const { data, error } = await supabase
+      .from('subscriptions')
+      .select('id, name, expected_amount, category_id, account_id, billing_day, note')
+      .eq('household_id', householdId)
+      .order('billing_day', { ascending: true })
+      .order('name', { ascending: true })
+
+    if (error) throw error
+    return (data ?? []) as Subscription[]
+  },
+}
+

--- a/web/tests/api/subscriptions_list.test.ts
+++ b/web/tests/api/subscriptions_list.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+import * as route from '@/app/api/subscriptions/route'
+
+vi.mock('@/server/utils/auth', () => ({
+  getSession: vi.fn(),
+  assertHouseholdMember: vi.fn(),
+}))
+
+vi.mock('@/server/repositories/subscriptionsRepository', () => ({
+  subscriptionsRepository: {
+    list: vi.fn(),
+  },
+}))
+
+import * as authModule from '@/server/utils/auth'
+import type { Session } from '@/server/utils/auth'
+import * as repoModule from '@/server/repositories/subscriptionsRepository'
+import type { Subscription } from '@/server/repositories/subscriptionsRepository'
+import { unauthorized, forbidden } from '@/server/utils/errors'
+
+function makeReq(headers: Record<string, string> = {}): NextRequest {
+  const h = new Headers(headers)
+  return { headers: h } as unknown as NextRequest
+}
+
+describe('GET /api/subscriptions', () => {
+  const getSession = vi.mocked(authModule.getSession)
+  const assertHouseholdMember = vi.mocked(authModule.assertHouseholdMember)
+  const subscriptionsRepository = vi.mocked(repoModule.subscriptionsRepository)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 401 when unauthorized', async () => {
+    getSession.mockRejectedValue(unauthorized())
+    const req = makeReq()
+    const res = await route.GET(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 when household scope missing', async () => {
+    const session: Session = { userId: 'u-1', token: 't' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockRejectedValue(forbidden('household scope required'))
+    const req = makeReq()
+    const res = await route.GET(req)
+    expect(res.status).toBe(403)
+    const json = await res.json()
+    expect(json.code).toBe('FORBIDDEN')
+  })
+
+  it('returns 200 with subscriptions list', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+    const list: Subscription[] = [
+      {
+        id: 's-1',
+        name: 'Netflix',
+        expected_amount: 1200,
+        category_id: 'c-1',
+        account_id: 'a-1',
+        billing_day: 15,
+        note: null,
+      },
+      {
+        id: 's-2',
+        name: 'Spotify',
+        expected_amount: 980,
+        category_id: 'c-2',
+        account_id: 'a-1',
+        billing_day: 20,
+        note: 'Family plan',
+      },
+    ]
+    subscriptionsRepository.list.mockResolvedValue(list)
+
+    const req = makeReq({ 'x-household-id': 'h-1' })
+    const res = await route.GET(req)
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual(list)
+    expect(subscriptionsRepository.list).toHaveBeenCalledWith('h-1')
+  })
+})
+


### PR DESCRIPTION
## 実装内容
- SubscriptionsRepository 実装（`list(householdId)`）
- APIハンドラ `GET /api/subscriptions` 追加
- 単体テスト追加（未認証/権限欠如/正常系）

## 参照設計書
- docs/design/detail/v1.0/feature/api_detail.md（Subscriptions）
- docs/design/base/v1.0/api.md
- docs/design/base/v1.0/database.md

## テスト結果
- [x] 単体テスト: 通過（vitest）
- [ ] 統合テスト: 対象外
- [ ] 手動テスト: 未

## 確認事項
- [ ] コードレビュー対象
- [ ] 設計書との整合性確認
- [ ] パフォーマンス確認（必要に応じて）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a GET /api/subscriptions endpoint to retrieve your household’s subscriptions as JSON. Results are sorted by billing day and then by name, and include key details like name, expected amount, category, account, billing day, and notes.
  - Clear error responses for unauthorized access (401) and missing household permissions (403).

- Tests
  - Added comprehensive tests covering success and error scenarios for the new subscriptions endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->