### PR TITLE
API-021: サブスク登録（POST /api/subscriptions）

### DIFF
--- a/web/app/api/subscriptions/route.ts
+++ b/web/app/api/subscriptions/route.ts
@@ -1,7 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { assertHouseholdMember, getSession } from '@/server/utils/auth'
-import { normalizeError, toErrorBody } from '@/server/utils/errors'
+import { normalizeError, toErrorBody, badRequest } from '@/server/utils/errors'
 import { subscriptionsRepository } from '@/server/repositories/subscriptionsRepository'
+import { subscriptionCreateSchema } from '@/server/schemas/subscription'
 
 export async function GET(req: NextRequest) {
   try {
@@ -16,3 +17,22 @@ export async function GET(req: NextRequest) {
   }
 }
 
+export async function POST(req: NextRequest) {
+  try {
+    const session = await getSession(req)
+    await assertHouseholdMember(session)
+
+    const json = await req.json().catch(() => ({}))
+    const parsed = subscriptionCreateSchema.safeParse(json)
+    if (!parsed.success) {
+      const message = parsed.error.message
+      throw badRequest(message, parsed.error)
+    }
+
+    const created = await subscriptionsRepository.create(session.householdId!, parsed.data)
+    return NextResponse.json(created, { status: 201 })
+  } catch (e: unknown) {
+    const err = normalizeError(e)
+    return NextResponse.json(toErrorBody(err), { status: err.status })
+  }
+}

--- a/web/server/repositories/subscriptionsRepository.ts
+++ b/web/server/repositories/subscriptionsRepository.ts
@@ -23,5 +23,35 @@ export const subscriptionsRepository = {
     if (error) throw error
     return (data ?? []) as Subscription[]
   },
+  async create(
+    householdId: string,
+    input: {
+      name: string
+      expected_amount: number
+      category_id: string
+      account_id: string
+      billing_day: number
+      note?: string | null
+    },
+  ): Promise<Subscription> {
+    const supabase = createSupabaseAdmin()
+    const { data, error } = await supabase
+      .from('subscriptions')
+      .insert({
+        household_id: householdId,
+        name: input.name,
+        expected_amount: input.expected_amount,
+        category_id: input.category_id,
+        account_id: input.account_id,
+        billing_day: input.billing_day,
+        note: input.note ?? null,
+      })
+      .select('id, name, expected_amount, category_id, account_id, billing_day, note')
+      .single()
+
+    if (error) throw error
+    if (!data) throw new Error('Failed to create subscription')
+    return data as Subscription
+  },
 }
 

--- a/web/server/schemas/subscription.ts
+++ b/web/server/schemas/subscription.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod'
+
+export const subscriptionCreateSchema = z.object({
+  name: z.string().min(1, 'name is required').max(100),
+  expected_amount: z.number().finite(),
+  category_id: z.string().min(1, 'category_id is required'),
+  account_id: z.string().min(1, 'account_id is required'),
+  billing_day: z.number().int().min(1).max(31),
+  note: z.string().max(500).nullable().optional(),
+})
+
+export type SubscriptionCreateInput = z.infer<typeof subscriptionCreateSchema>
+

--- a/web/tests/api/subscriptions_create.test.ts
+++ b/web/tests/api/subscriptions_create.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+import * as route from '@/app/api/subscriptions/route'
+
+vi.mock('@/server/utils/auth', () => ({
+  getSession: vi.fn(),
+  assertHouseholdMember: vi.fn(),
+}))
+
+vi.mock('@/server/repositories/subscriptionsRepository', () => ({
+  subscriptionsRepository: {
+    create: vi.fn(),
+  },
+}))
+
+import * as authModule from '@/server/utils/auth'
+import type { Session } from '@/server/utils/auth'
+import * as repoModule from '@/server/repositories/subscriptionsRepository'
+import type { Subscription } from '@/server/repositories/subscriptionsRepository'
+import { unauthorized, forbidden } from '@/server/utils/errors'
+
+function makeReq(body: unknown, headers: Record<string, string> = {}): NextRequest {
+  const h = new Headers(headers)
+  return {
+    headers: h,
+    json: async () => body,
+  } as unknown as NextRequest
+}
+
+describe('POST /api/subscriptions', () => {
+  const getSession = vi.mocked(authModule.getSession)
+  const assertHouseholdMember = vi.mocked(authModule.assertHouseholdMember)
+  const subscriptionsRepository = vi.mocked(repoModule.subscriptionsRepository)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 400 when body is invalid', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+
+    const req = makeReq({})
+    const res = await route.POST(req)
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('returns 401 when unauthorized', async () => {
+    getSession.mockRejectedValue(unauthorized())
+
+    const req = makeReq({
+      name: 'Netflix',
+      expected_amount: 1200,
+      category_id: 'c-1',
+      account_id: 'a-1',
+      billing_day: 15,
+      note: null,
+    })
+    const res = await route.POST(req)
+    expect(res.status).toBe(401)
+    const json = await res.json()
+    expect(json.code).toBe('UNAUTHORIZED')
+  })
+
+  it('returns 403 when household scope missing', async () => {
+    const session: Session = { userId: 'u-1', token: 't' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockRejectedValue(forbidden('household scope required'))
+
+    const req = makeReq({
+      name: 'Netflix',
+      expected_amount: 1200,
+      category_id: 'c-1',
+      account_id: 'a-1',
+      billing_day: 15,
+      note: null,
+    })
+    const res = await route.POST(req)
+    expect(res.status).toBe(403)
+    const json = await res.json()
+    expect(json.code).toBe('FORBIDDEN')
+  })
+
+  it('creates subscription and returns 201', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+
+    const sub: Subscription = {
+      id: 's-1',
+      name: 'Netflix',
+      expected_amount: 1200,
+      category_id: 'c-1',
+      account_id: 'a-1',
+      billing_day: 15,
+      note: null,
+    }
+    subscriptionsRepository.create.mockResolvedValue(sub)
+
+    const req = makeReq(
+      {
+        name: 'Netflix',
+        expected_amount: 1200,
+        category_id: 'c-1',
+        account_id: 'a-1',
+        billing_day: 15,
+        note: null,
+      },
+      { 'x-household-id': 'h-1' },
+    )
+    const res = await route.POST(req)
+    expect(res.status).toBe(201)
+    const json = await res.json()
+    expect(json).toEqual(sub)
+    expect(subscriptionsRepository.create).toHaveBeenCalledWith('h-1', {
+      name: 'Netflix',
+      expected_amount: 1200,
+      category_id: 'c-1',
+      account_id: 'a-1',
+      billing_day: 15,
+      note: null,
+    })
+  })
+})
+


### PR DESCRIPTION
## 実装内容
- サブスク登録API `POST /api/subscriptions` を実装
- Zodバリデーションを追加（`subscriptionCreateSchema`）
- Repositoryに`create`を追加してSupabase経由で作成
- 単体テスト `subscriptions_create.test.ts` を追加

## 参照設計書
- docs/design/detail/v1.0/feature/api_detail.md
- docs/design/base/v1.0/api.md

## テスト結果
- [ ] 単体テスト: 通過（ローカル実行想定）
- [ ] 統合テスト: 通過
- [ ] 手動テスト: 通過

## 確認事項
- [ ] コードレビュー対象
- [ ] 設計書との整合性確認
- [ ] パフォーマンス確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced an API endpoint to create subscriptions, with authentication and household access checks.
  - Input validation ensures correct fields and formats, returning clear errors for invalid requests.
  - Successful creation returns the new subscription details with a Created response.

- Tests
  - Added comprehensive tests covering invalid input, unauthorized access, missing household permissions, and successful creation flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->