### PR TITLE
API-022: サブスク更新（PATCH /api/subscriptions/:id）

### DIFF
--- a/web/app/api/subscriptions/[id]/route.ts
+++ b/web/app/api/subscriptions/[id]/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { assertHouseholdMember, getSession } from '@/server/utils/auth'
+import { normalizeError, toErrorBody, badRequest } from '@/server/utils/errors'
+import { subscriptionsRepository } from '@/server/repositories/subscriptionsRepository'
+import { subscriptionUpdateSchema } from '@/server/schemas/subscription'
+
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const session = await getSession(req)
+    await assertHouseholdMember(session)
+
+    const json = await req.json().catch(() => ({}))
+    const parsed = subscriptionUpdateSchema.safeParse(json)
+    if (!parsed.success) {
+      const message = parsed.error.message
+      throw badRequest(message, parsed.error)
+    }
+
+    const { id } = await params
+    const updated = await subscriptionsRepository.update(
+      session.householdId!,
+      id,
+      parsed.data,
+    )
+    return NextResponse.json(updated, { status: 200 })
+  } catch (e: unknown) {
+    const err = normalizeError(e)
+    return NextResponse.json(toErrorBody(err), { status: err.status })
+  }
+}
+

--- a/web/server/repositories/subscriptionsRepository.ts
+++ b/web/server/repositories/subscriptionsRepository.ts
@@ -53,5 +53,29 @@ export const subscriptionsRepository = {
     if (!data) throw new Error('Failed to create subscription')
     return data as Subscription
   },
-}
+  async update(
+    householdId: string,
+    id: string,
+    input: Partial<{
+      name: string
+      expected_amount: number
+      category_id: string
+      account_id: string
+      billing_day: number
+      note: string | null
+    }>,
+  ): Promise<Subscription> {
+    const supabase = createSupabaseAdmin()
+    const { data, error } = await supabase
+      .from('subscriptions')
+      .update(input)
+      .eq('household_id', householdId)
+      .eq('id', id)
+      .select('id, name, expected_amount, category_id, account_id, billing_day, note')
+      .single()
 
+    if (error) throw error
+    if (!data) throw new Error('Subscription not found')
+    return data as Subscription
+  },
+}

--- a/web/server/schemas/subscription.ts
+++ b/web/server/schemas/subscription.ts
@@ -11,3 +11,5 @@ export const subscriptionCreateSchema = z.object({
 
 export type SubscriptionCreateInput = z.infer<typeof subscriptionCreateSchema>
 
+export const subscriptionUpdateSchema = subscriptionCreateSchema.partial()
+export type SubscriptionUpdateInput = z.infer<typeof subscriptionUpdateSchema>

--- a/web/tests/api/subscriptions_update.test.ts
+++ b/web/tests/api/subscriptions_update.test.ts
@@ -1,0 +1,105 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+import * as route from '@/app/api/subscriptions/[id]/route'
+
+vi.mock('@/server/utils/auth', () => ({
+  getSession: vi.fn(),
+  assertHouseholdMember: vi.fn(),
+}))
+
+vi.mock('@/server/repositories/subscriptionsRepository', () => ({
+  subscriptionsRepository: {
+    update: vi.fn(),
+  },
+}))
+
+import * as authModule from '@/server/utils/auth'
+import type { Session } from '@/server/utils/auth'
+import * as repoModule from '@/server/repositories/subscriptionsRepository'
+import type { Subscription } from '@/server/repositories/subscriptionsRepository'
+import { unauthorized, forbidden } from '@/server/utils/errors'
+
+function makeReq(body: unknown, headers: Record<string, string> = {}): NextRequest {
+  const h = new Headers(headers)
+  return {
+    headers: h,
+    json: async () => body,
+  } as unknown as NextRequest
+}
+
+describe('PATCH /api/subscriptions/:id', () => {
+  const getSession = vi.mocked(authModule.getSession)
+  const assertHouseholdMember = vi.mocked(authModule.assertHouseholdMember)
+  const subscriptionsRepository = vi.mocked(repoModule.subscriptionsRepository)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 400 when body is invalid', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+
+    // invalid type
+    const req = makeReq({ expected_amount: 'invalid' })
+    const res = await route.PATCH(req, { params: Promise.resolve({ id: 's-1' }) })
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('returns 401 when unauthorized', async () => {
+    getSession.mockRejectedValue(unauthorized())
+
+    const req = makeReq({ name: 'Netflix' })
+    const res = await route.PATCH(req, { params: Promise.resolve({ id: 's-1' }) })
+    expect(res.status).toBe(401)
+    const json = await res.json()
+    expect(json.code).toBe('UNAUTHORIZED')
+  })
+
+  it('returns 403 when household scope missing', async () => {
+    const session: Session = { userId: 'u-1', token: 't' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockRejectedValue(forbidden('household scope required'))
+
+    const req = makeReq({ name: 'Netflix' })
+    const res = await route.PATCH(req, { params: Promise.resolve({ id: 's-1' }) })
+    expect(res.status).toBe(403)
+    const json = await res.json()
+    expect(json.code).toBe('FORBIDDEN')
+  })
+
+  it('updates subscription and returns 200', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+
+    const sub: Subscription = {
+      id: 's-1',
+      name: 'Netflix',
+      expected_amount: 1200,
+      category_id: 'c-1',
+      account_id: 'a-1',
+      billing_day: 15,
+      note: null,
+    }
+    subscriptionsRepository.update.mockResolvedValue(sub)
+
+    const req = makeReq({ name: 'Netflix', billing_day: 15 }, { 'x-household-id': 'h-1' })
+    const res = await route.PATCH(req, { params: Promise.resolve({ id: 's-1' }) })
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual(sub)
+    expect(subscriptionsRepository.update).toHaveBeenCalledWith('h-1', 's-1', {
+      name: 'Netflix',
+      billing_day: 15,
+    })
+  })
+})


### PR DESCRIPTION
## 実装内容
- サブスク更新APIのController/Service（PATCH /api/subscriptions/:id）
- Repositoryにupdateを追加
- subscriptionUpdateSchema追加
- 単体テスト追加（Vitest）

## 参照設計書
- docs/design/detail/v1.0/feature/api_detail.md

## テスト結果
- [x] 単体テスト: 通過
- [x] 統合テスト: 対象外（該当なし）
- [x] 手動テスト: 対象外（モック）

## 確認事項
- [x] コードレビュー対象
- [x] 設計書との整合性確認
- [x] パフォーマンス確認（クエリ簡易）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added support to update subscriptions by ID. You can partially edit fields like name, expected amount, category, account, billing day, and note.
  - Returns the updated subscription on success and provides consistent error responses.
  - Enforces proper authorization and household access.

- Tests
  - Added tests covering validation errors, unauthorized/forbidden access, and successful updates for the subscriptions update endpoint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->