### PR TITLE
API-023: サブスク削除（DELETE /api/subscriptions/:id）

### DIFF
--- a/web/app/api/subscriptions/[id]/route.ts
+++ b/web/app/api/subscriptions/[id]/route.ts
@@ -32,3 +32,19 @@ export async function PATCH(
   }
 }
 
+export async function DELETE(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const session = await getSession(req)
+    await assertHouseholdMember(session)
+
+    const { id } = await params
+    await subscriptionsRepository.remove(session.householdId!, id)
+    return new NextResponse(null, { status: 204 })
+  } catch (e: unknown) {
+    const err = normalizeError(e)
+    return NextResponse.json(toErrorBody(err), { status: err.status })
+  }
+}

--- a/web/server/repositories/subscriptionsRepository.ts
+++ b/web/server/repositories/subscriptionsRepository.ts
@@ -23,6 +23,19 @@ export const subscriptionsRepository = {
     if (error) throw error
     return (data ?? []) as Subscription[]
   },
+  async remove(householdId: string, id: string): Promise<void> {
+    const supabase = createSupabaseAdmin()
+    const { data, error } = await supabase
+      .from('subscriptions')
+      .delete()
+      .eq('household_id', householdId)
+      .eq('id', id)
+      .select('id')
+      .single()
+
+    if (error) throw error
+    if (!data) throw new Error('Subscription not found')
+  },
   async create(
     householdId: string,
     input: {

--- a/web/tests/api/subscriptions_delete.test.ts
+++ b/web/tests/api/subscriptions_delete.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+import * as route from '@/app/api/subscriptions/[id]/route'
+
+vi.mock('@/server/utils/auth', () => ({
+  getSession: vi.fn(),
+  assertHouseholdMember: vi.fn(),
+}))
+
+vi.mock('@/server/repositories/subscriptionsRepository', () => ({
+  subscriptionsRepository: {
+    remove: vi.fn(),
+  },
+}))
+
+import * as authModule from '@/server/utils/auth'
+import type { Session } from '@/server/utils/auth'
+import * as repoModule from '@/server/repositories/subscriptionsRepository'
+import { unauthorized, forbidden } from '@/server/utils/errors'
+
+function makeReq(headers: Record<string, string> = {}): NextRequest {
+  const h = new Headers(headers)
+  return {
+    headers: h,
+  } as unknown as NextRequest
+}
+
+describe('DELETE /api/subscriptions/:id', () => {
+  const getSession = vi.mocked(authModule.getSession)
+  const assertHouseholdMember = vi.mocked(authModule.assertHouseholdMember)
+  const subscriptionsRepository = vi.mocked(repoModule.subscriptionsRepository)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 401 when unauthorized', async () => {
+    getSession.mockRejectedValue(unauthorized())
+
+    const req = makeReq()
+    const res = await route.DELETE(req, { params: Promise.resolve({ id: 's-1' }) })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 when household scope missing', async () => {
+    const session: Session = { userId: 'u-1', token: 't' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockRejectedValue(forbidden('household scope required'))
+
+    const req = makeReq()
+    const res = await route.DELETE(req, { params: Promise.resolve({ id: 's-1' }) })
+    expect(res.status).toBe(403)
+    const json = await res.json()
+    expect(json.code).toBe('FORBIDDEN')
+  })
+
+  it('deletes subscription and returns 204', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+    subscriptionsRepository.remove.mockResolvedValue(undefined)
+
+    const req = makeReq({ 'x-household-id': 'h-1' })
+    const res = await route.DELETE(req, { params: Promise.resolve({ id: 's-1' }) })
+    expect(res.status).toBe(204)
+    expect(subscriptionsRepository.remove).toHaveBeenCalledWith('h-1', 's-1')
+  })
+})
+


### PR DESCRIPTION
## 実装内容
- サブスク削除APIのController/Service実装
- Repositoryにremoveメソッド追加
- 単体テスト追加・全テスト通過

## 参照設計書
- docs/design/detail/v1.0/feature/api_detail.md

## テスト結果
- [x] 単体テスト: 通過
- [x] 統合テスト: 通過（該当範囲）
- [x] 手動テスト: 簡易確認

## 確認事項
- [x] コードレビュー対象
- [x] 設計書との整合性確認
- [x] パフォーマンス確認（削除操作のため影響軽微）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added API support to delete subscriptions by ID.
  - Returns 204 No Content on success and consistent JSON error responses when access is unauthorized or forbidden.
  - Behavior aligns with existing subscription update endpoint for a consistent experience.

- Tests
  - Added tests covering unauthorized access, forbidden access, and successful deletion paths for the delete subscription API.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->