### PR TITLE
API-024: サブスク確定（/api/subscriptions/:id/confirm）

### DIFF
--- a/web/app/api/subscriptions/[id]/confirm/route.ts
+++ b/web/app/api/subscriptions/[id]/confirm/route.ts
@@ -3,6 +3,18 @@ import { assertHouseholdMember, getSession } from '@/server/utils/auth'
 import { normalizeError, toErrorBody, badRequest } from '@/server/utils/errors'
 import { subscriptionsRepository } from '@/server/repositories/subscriptionsRepository'
 
+type ConfirmBody = { amount?: number }
+
+function parseConfirmBody(raw: unknown): ConfirmBody {
+  if (raw && typeof raw === 'object') {
+    const rec = raw as Record<string, unknown>
+    if (rec.amount === undefined) return {}
+    if (typeof rec.amount !== 'number') throw badRequest('amount must be a number')
+    return { amount: rec.amount }
+  }
+  return {}
+}
+
 export async function POST(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
@@ -11,10 +23,13 @@ export async function POST(
     const session = await getSession(req)
     await assertHouseholdMember(session)
 
-    const json = await req.json().catch(() => ({} as any))
-    if (json && 'amount' in json && typeof json.amount !== 'number') {
-      throw badRequest('amount must be a number')
+    let raw: unknown
+    try {
+      raw = await req.json()
+    } catch {
+      raw = {}
     }
+    const json = parseConfirmBody(raw)
 
     const { id } = await params
     const tx = await subscriptionsRepository.confirm(

--- a/web/app/api/subscriptions/[id]/confirm/route.ts
+++ b/web/app/api/subscriptions/[id]/confirm/route.ts
@@ -1,0 +1,31 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { assertHouseholdMember, getSession } from '@/server/utils/auth'
+import { normalizeError, toErrorBody, badRequest } from '@/server/utils/errors'
+import { subscriptionsRepository } from '@/server/repositories/subscriptionsRepository'
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const session = await getSession(req)
+    await assertHouseholdMember(session)
+
+    const json = await req.json().catch(() => ({} as any))
+    if (json && 'amount' in json && typeof json.amount !== 'number') {
+      throw badRequest('amount must be a number')
+    }
+
+    const { id } = await params
+    const tx = await subscriptionsRepository.confirm(
+      session.householdId!,
+      id,
+      { amount: json.amount, userId: session.userId },
+    )
+    return NextResponse.json(tx, { status: 201 })
+  } catch (e: unknown) {
+    const err = normalizeError(e)
+    return NextResponse.json(toErrorBody(err), { status: err.status })
+  }
+}
+

--- a/web/server/repositories/subscriptionsRepository.ts
+++ b/web/server/repositories/subscriptionsRepository.ts
@@ -23,6 +23,70 @@ export const subscriptionsRepository = {
     if (error) throw error
     return (data ?? []) as Subscription[]
   },
+  async confirm(
+    householdId: string,
+    id: string,
+    options: { amount?: number; occurred_on?: string; userId: string },
+  ): Promise<import('./transactionsRepository').Transaction> {
+    const supabase = createSupabaseAdmin()
+
+    // Fetch subscription to derive defaults (amount/occurred_on)
+    const { data: sub, error: subErr } = await supabase
+      .from('subscriptions')
+      .select('id, expected_amount, billing_day')
+      .eq('household_id', householdId)
+      .eq('id', id)
+      .single()
+
+    if (subErr) throw subErr
+    if (!sub) throw new Error('Subscription not found')
+
+    const amount = options.amount ?? (sub as any).expected_amount
+
+    // Compute occurred_on = current month with billing_day (clamped to last day)
+    const occurred_on = options.occurred_on ?? (() => {
+      const now = new Date()
+      const year = now.getUTCFullYear()
+      const month0 = now.getUTCMonth() // 0-based
+      const billingDay: number = (sub as any).billing_day
+      // Last day of current month in UTC
+      const lastDay = new Date(Date.UTC(year, month0 + 1, 0)).getUTCDate()
+      const day = Math.min(Math.max(billingDay, 1), lastDay)
+      const mm = String(month0 + 1).padStart(2, '0')
+      const dd = String(day).padStart(2, '0')
+      return `${year}-${mm}-${dd}`
+    })()
+
+    const { data: rpcData, error: rpcErr } = await supabase.rpc(
+      'confirm_subscription_tx',
+      {
+        _household: householdId,
+        _subscription: id,
+        _amount: amount,
+        _occurred_on: occurred_on,
+        _user: options.userId,
+      },
+    )
+    if (rpcErr) throw rpcErr
+
+    const createdId: string | undefined = Array.isArray(rpcData)
+      ? (rpcData[0] as any)?.id
+      : (rpcData as any)?.id
+    if (!createdId) throw new Error('Failed to confirm subscription')
+
+    // Fetch created transaction to return full object
+    const { data: tx, error: txErr } = await supabase
+      .from('transactions')
+      .select(
+        'id, kind, occurred_on, amount, category_id, account_id, place, memo',
+      )
+      .eq('household_id', householdId)
+      .eq('id', createdId)
+      .single()
+    if (txErr) throw txErr
+    if (!tx) throw new Error('Confirmed transaction not found')
+    return tx as import('./transactionsRepository').Transaction
+  },
   async remove(householdId: string, id: string): Promise<void> {
     const supabase = createSupabaseAdmin()
     const { data, error } = await supabase

--- a/web/server/repositories/subscriptionsRepository.ts
+++ b/web/server/repositories/subscriptionsRepository.ts
@@ -41,14 +41,16 @@ export const subscriptionsRepository = {
     if (subErr) throw subErr
     if (!sub) throw new Error('Subscription not found')
 
-    const amount = options.amount ?? (sub as any).expected_amount
+    type SubRow = { id: string; expected_amount: number; billing_day: number }
+    const subRow = sub as unknown as SubRow
+    const amount = options.amount ?? subRow.expected_amount
 
     // Compute occurred_on = current month with billing_day (clamped to last day)
     const occurred_on = options.occurred_on ?? (() => {
       const now = new Date()
       const year = now.getUTCFullYear()
       const month0 = now.getUTCMonth() // 0-based
-      const billingDay: number = (sub as any).billing_day
+      const billingDay: number = subRow.billing_day
       // Last day of current month in UTC
       const lastDay = new Date(Date.UTC(year, month0 + 1, 0)).getUTCDate()
       const day = Math.min(Math.max(billingDay, 1), lastDay)
@@ -69,9 +71,10 @@ export const subscriptionsRepository = {
     )
     if (rpcErr) throw rpcErr
 
+    type RpcId = { id: string }
     const createdId: string | undefined = Array.isArray(rpcData)
-      ? (rpcData[0] as any)?.id
-      : (rpcData as any)?.id
+      ? (rpcData[0] as unknown as RpcId | undefined)?.id
+      : (rpcData as unknown as RpcId | null)?.id
     if (!createdId) throw new Error('Failed to confirm subscription')
 
     // Fetch created transaction to return full object

--- a/web/tests/api/subscriptions_confirm.test.ts
+++ b/web/tests/api/subscriptions_confirm.test.ts
@@ -17,6 +17,7 @@ vi.mock('@/server/repositories/subscriptionsRepository', () => ({
 import * as authModule from '@/server/utils/auth'
 import type { Session } from '@/server/utils/auth'
 import * as repoModule from '@/server/repositories/subscriptionsRepository'
+import type { Transaction } from '@/server/repositories/transactionsRepository'
 import { unauthorized, forbidden } from '@/server/utils/errors'
 
 function makeReq(body?: unknown, headers: Record<string, string> = {}): NextRequest {
@@ -64,7 +65,7 @@ describe('POST /api/subscriptions/:id/confirm', () => {
     const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
     getSession.mockResolvedValue(session)
     assertHouseholdMember.mockResolvedValue()
-    const tx = {
+    const tx: Transaction = {
       id: 't-1',
       kind: 'expense',
       occurred_on: '2025-09-15',
@@ -74,7 +75,7 @@ describe('POST /api/subscriptions/:id/confirm', () => {
       place: null,
       memo: 'Netflix',
     }
-    subscriptionsRepository.confirm.mockResolvedValue(tx as any)
+    subscriptionsRepository.confirm.mockResolvedValue(tx)
 
     const req = makeReq({ amount: 1500 }, { 'x-household-id': 'h-1' })
     const res = await route.POST(req, { params: Promise.resolve({ id: 's-1' }) })

--- a/web/tests/api/subscriptions_confirm.test.ts
+++ b/web/tests/api/subscriptions_confirm.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+import * as route from '@/app/api/subscriptions/[id]/confirm/route'
+
+vi.mock('@/server/utils/auth', () => ({
+  getSession: vi.fn(),
+  assertHouseholdMember: vi.fn(),
+}))
+
+vi.mock('@/server/repositories/subscriptionsRepository', () => ({
+  subscriptionsRepository: {
+    confirm: vi.fn(),
+  },
+}))
+
+import * as authModule from '@/server/utils/auth'
+import type { Session } from '@/server/utils/auth'
+import * as repoModule from '@/server/repositories/subscriptionsRepository'
+import { unauthorized, forbidden } from '@/server/utils/errors'
+
+function makeReq(body?: unknown, headers: Record<string, string> = {}): NextRequest {
+  const h = new Headers(headers)
+  return {
+    headers: h,
+    json: async () => (body ?? {}),
+  } as unknown as NextRequest
+}
+
+describe('POST /api/subscriptions/:id/confirm', () => {
+  const getSession = vi.mocked(authModule.getSession)
+  const assertHouseholdMember = vi.mocked(authModule.assertHouseholdMember)
+  const subscriptionsRepository = vi.mocked(repoModule.subscriptionsRepository)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 401 when unauthorized', async () => {
+    getSession.mockRejectedValue(unauthorized())
+
+    const req = makeReq()
+    const res = await route.POST(req, { params: Promise.resolve({ id: 's-1' }) })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 when household scope missing', async () => {
+    const session: Session = { userId: 'u-1', token: 't' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockRejectedValue(forbidden('household scope required'))
+
+    const req = makeReq()
+    const res = await route.POST(req, { params: Promise.resolve({ id: 's-1' }) })
+    expect(res.status).toBe(403)
+    const json = await res.json()
+    expect(json.code).toBe('FORBIDDEN')
+  })
+
+  it('confirms with specified amount and returns 201 with transaction', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+    const tx = {
+      id: 't-1',
+      kind: 'expense',
+      occurred_on: '2025-09-15',
+      amount: 1500,
+      category_id: 'c-1',
+      account_id: 'a-1',
+      place: null,
+      memo: 'Netflix',
+    }
+    subscriptionsRepository.confirm.mockResolvedValue(tx as any)
+
+    const req = makeReq({ amount: 1500 }, { 'x-household-id': 'h-1' })
+    const res = await route.POST(req, { params: Promise.resolve({ id: 's-1' }) })
+    expect(res.status).toBe(201)
+    const json = await res.json()
+    expect(json).toEqual(tx)
+    expect(subscriptionsRepository.confirm).toHaveBeenCalledWith('h-1', 's-1', { amount: 1500, userId: 'u-1' })
+  })
+})
+


### PR DESCRIPTION
## 実装内容
- サブスク確定APIを実装（POST /api/subscriptions/:id/confirm）
- RPC `confirm_subscription_tx` を呼び出し、作成された取引を返却
- repository: `subscriptionsRepository.confirm` を追加（定義読込→RPC→取引取得）
- ルート: `web/app/api/subscriptions/[id]/confirm/route.ts` を追加
- テスト: `web/tests/api/subscriptions_confirm.test.ts` を追加（401/403/201）

## 参照設計書
- docs/design/detail/v1.0/feature/backend_detail.md（confirm_subscription_tx）
- docs/design/base/v1.0/api.md

## テスト結果
- [x] 単体テスト: 通過（vitest）
- [x] 統合テスト: N/A（本PR範囲外）
- [x] 手動テスト: N/A（本PR範囲外）

## 確認事項
- [x] コードレビュー対象
- [x] 設計書との整合性確認
- [ ] パフォーマンス確認


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a POST API to confirm a subscription and create a transaction.
  - Supports an optional custom amount and returns 201 with the transaction payload.
  - Enforces authentication and household membership checks; returns appropriate error statuses.

- **Tests**
  - Added tests for unauthorized (401), forbidden (403), and successful confirmation (201) flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->