### PR TITLE
API-025: 通知一覧（GET /api/notifications?read=false）

### DIFF
--- a/web/app/api/notifications/route.ts
+++ b/web/app/api/notifications/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { assertHouseholdMember, getSession } from '@/server/utils/auth'
+import { normalizeError, toErrorBody } from '@/server/utils/errors'
+import { notificationsRepository } from '@/server/repositories/notificationsRepository'
+
+export async function GET(req: NextRequest) {
+  try {
+    const session = await getSession(req)
+    await assertHouseholdMember(session)
+
+    const url = new URL(req.url)
+    const readParam = url.searchParams.get('read')
+    const onlyUnread = readParam === 'false'
+
+    const list = await notificationsRepository.list(
+      session.householdId!,
+      session.userId,
+      { onlyUnread },
+    )
+    return NextResponse.json(list, { status: 200 })
+  } catch (e: unknown) {
+    const err = normalizeError(e)
+    return NextResponse.json(toErrorBody(err), { status: err.status })
+  }
+}
+

--- a/web/server/repositories/notificationsRepository.ts
+++ b/web/server/repositories/notificationsRepository.ts
@@ -1,0 +1,36 @@
+import { createSupabaseAdmin } from '@/server/clients/supabase'
+
+export type Notification = {
+  id: string
+  type: 'subscription_reminder' | 'comment' | 'reaction'
+  payload: Record<string, unknown>
+  read: boolean
+  created_at: string
+}
+
+export const notificationsRepository = {
+  async list(
+    householdId: string,
+    userId: string,
+    opts?: { onlyUnread?: boolean },
+  ): Promise<Notification[]> {
+    const supabase = createSupabaseAdmin()
+    let query = supabase
+      .from('notifications')
+      .select('id, type, payload, read, created_at')
+      .eq('household_id', householdId)
+      .eq('user_id', userId)
+
+    if (opts?.onlyUnread) {
+      query = query.eq('read', false)
+    }
+
+    const { data, error } = await query
+      .order('read', { ascending: true })
+      .order('created_at', { ascending: false })
+
+    if (error) throw error
+    return (data ?? []) as Notification[]
+  },
+}
+

--- a/web/tests/api/notifications_list.test.ts
+++ b/web/tests/api/notifications_list.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+import * as route from '@/app/api/notifications/route'
+
+vi.mock('@/server/utils/auth', () => ({
+  getSession: vi.fn(),
+  assertHouseholdMember: vi.fn(),
+}))
+
+vi.mock('@/server/repositories/notificationsRepository', () => ({
+  notificationsRepository: {
+    list: vi.fn(),
+  },
+}))
+
+import * as authModule from '@/server/utils/auth'
+import type { Session } from '@/server/utils/auth'
+import * as repoModule from '@/server/repositories/notificationsRepository'
+import type { Notification } from '@/server/repositories/notificationsRepository'
+import { unauthorized, forbidden } from '@/server/utils/errors'
+
+function makeReq(url: string, headers: Record<string, string> = {}): NextRequest {
+  const h = new Headers(headers)
+  return { headers: h, url } as unknown as NextRequest
+}
+
+describe('GET /api/notifications', () => {
+  const getSession = vi.mocked(authModule.getSession)
+  const assertHouseholdMember = vi.mocked(authModule.assertHouseholdMember)
+  const notificationsRepository = vi.mocked(repoModule.notificationsRepository)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 401 when unauthorized', async () => {
+    getSession.mockRejectedValue(unauthorized())
+    const req = makeReq('https://example.com/api/notifications')
+    const res = await route.GET(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 when household scope missing', async () => {
+    const session: Session = { userId: 'u-1', token: 't' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockRejectedValue(forbidden('household scope required'))
+    const req = makeReq('https://example.com/api/notifications')
+    const res = await route.GET(req)
+    expect(res.status).toBe(403)
+    const json = await res.json()
+    expect(json.code).toBe('FORBIDDEN')
+  })
+
+  it('returns 200 with notifications list (all, unread-first)', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+    const list: Notification[] = [
+      {
+        id: 'n-2',
+        type: 'comment',
+        payload: { comment_id: 'c-1' },
+        read: false,
+        created_at: new Date().toISOString(),
+      },
+      {
+        id: 'n-1',
+        type: 'reaction',
+        payload: { reaction: 'like' },
+        read: true,
+        created_at: new Date().toISOString(),
+      },
+    ]
+    notificationsRepository.list.mockResolvedValue(list)
+
+    const req = makeReq('https://example.com/api/notifications', {
+      'x-household-id': 'h-1',
+    })
+    const res = await route.GET(req)
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual(list)
+    expect(notificationsRepository.list).toHaveBeenCalledWith('h-1', 'u-1', {
+      onlyUnread: false,
+    })
+  })
+
+  it('filters only unread when read=false', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+    const list: Notification[] = []
+    notificationsRepository.list.mockResolvedValue(list)
+
+    const req = makeReq('https://example.com/api/notifications?read=false', {
+      'x-household-id': 'h-1',
+    })
+    const res = await route.GET(req)
+    expect(res.status).toBe(200)
+    await res.json()
+    expect(notificationsRepository.list).toHaveBeenCalledWith('h-1', 'u-1', {
+      onlyUnread: true,
+    })
+  })
+})
+


### PR DESCRIPTION
## 実装内容
- 通知一覧APIを実装（GET /api/notifications）
- クエリ  で未読のみ抽出
- 既定は未読優先 + 作成日時降順で返却
- Repository: 

## 参照設計書
- docs/design/detail/v1.0/feature/api_detail.md

## テスト結果
- [x] 単体テスト: 通過
- [x] 統合テスト: N/A（API層の単体テストで代替）
- [x] 手動テスト: 任意

## 確認事項
- [x] コードレビュー対象
- [x] 設計書との整合性確認
- [ ] パフォーマンス確認（通知件数が多い場合の挙動）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Notifications API endpoint to fetch a user’s household notifications.
  - Supports unread-only filtering via read=false.
  - Responses are sorted with unread first, then newest first.
  - Returns structured notification details (type, payload, read status, timestamp).
- Tests
  - Added coverage for authorization outcomes, unread filtering, header handling, and response formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->