### PR TITLE
API-026: 通知既読化（POST /api/notifications/:id/read）

### DIFF
--- a/web/app/api/notifications/[id]/read/route.ts
+++ b/web/app/api/notifications/[id]/read/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { assertHouseholdMember, getSession } from '@/server/utils/auth'
+import { normalizeError, toErrorBody } from '@/server/utils/errors'
+import { notificationsRepository } from '@/server/repositories/notificationsRepository'
+
+export async function POST(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const session = await getSession(req)
+    await assertHouseholdMember(session)
+
+    const { id } = await params
+    const updated = await notificationsRepository.markRead(
+      session.householdId!,
+      session.userId,
+      id,
+    )
+    return NextResponse.json(updated, { status: 200 })
+  } catch (e: unknown) {
+    const err = normalizeError(e)
+    return NextResponse.json(toErrorBody(err), { status: err.status })
+  }
+}
+

--- a/web/server/repositories/notificationsRepository.ts
+++ b/web/server/repositories/notificationsRepository.ts
@@ -32,5 +32,24 @@ export const notificationsRepository = {
     if (error) throw error
     return (data ?? []) as Notification[]
   },
+  async markRead(
+    householdId: string,
+    userId: string,
+    id: string,
+  ): Promise<Notification> {
+    const supabase = createSupabaseAdmin()
+    const { data, error } = await supabase
+      .from('notifications')
+      .update({ read: true })
+      .eq('id', id)
+      .eq('household_id', householdId)
+      .eq('user_id', userId)
+      .select('id, type, payload, read, created_at')
+      .single()
+
+    if (error) throw error
+    if (!data) throw new Error('Failed to mark notification as read')
+    return data as Notification
+  },
 }
 

--- a/web/tests/api/notifications_read.test.ts
+++ b/web/tests/api/notifications_read.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+import * as route from '@/app/api/notifications/[id]/read/route'
+
+vi.mock('@/server/utils/auth', () => ({
+  getSession: vi.fn(),
+  assertHouseholdMember: vi.fn(),
+}))
+
+vi.mock('@/server/repositories/notificationsRepository', () => ({
+  notificationsRepository: {
+    markRead: vi.fn(),
+  },
+}))
+
+import * as authModule from '@/server/utils/auth'
+import type { Session } from '@/server/utils/auth'
+import * as repoModule from '@/server/repositories/notificationsRepository'
+import type { Notification } from '@/server/repositories/notificationsRepository'
+import { unauthorized, forbidden } from '@/server/utils/errors'
+
+function makeReq(url: string, headers: Record<string, string> = {}): NextRequest {
+  const h = new Headers(headers)
+  return { headers: h, url } as unknown as NextRequest
+}
+
+describe('POST /api/notifications/:id/read', () => {
+  const getSession = vi.mocked(authModule.getSession)
+  const assertHouseholdMember = vi.mocked(authModule.assertHouseholdMember)
+  const notificationsRepository = vi.mocked(repoModule.notificationsRepository)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 401 when unauthorized', async () => {
+    getSession.mockRejectedValue(unauthorized())
+    const req = makeReq('https://example.com/api/notifications/n-1/read')
+    const res = await route.POST(req, { params: Promise.resolve({ id: 'n-1' }) })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 when household scope missing', async () => {
+    const session: Session = { userId: 'u-1', token: 't' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockRejectedValue(forbidden('household scope required'))
+    const req = makeReq('https://example.com/api/notifications/n-1/read')
+    const res = await route.POST(req, { params: Promise.resolve({ id: 'n-1' }) })
+    expect(res.status).toBe(403)
+    const json = await res.json()
+    expect(json.code).toBe('FORBIDDEN')
+  })
+
+  it('marks notification as read and returns updated entity', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+
+    const updated: Notification = {
+      id: 'n-1',
+      type: 'comment',
+      payload: { comment_id: 'c-1' },
+      read: true,
+      created_at: new Date().toISOString(),
+    }
+    notificationsRepository.markRead.mockResolvedValue(updated)
+
+    const req = makeReq('https://example.com/api/notifications/n-1/read', {
+      'x-household-id': 'h-1',
+    })
+    const res = await route.POST(req, { params: Promise.resolve({ id: 'n-1' }) })
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual(updated)
+    expect(notificationsRepository.markRead).toHaveBeenCalledWith('h-1', 'u-1', 'n-1')
+  })
+})
+


### PR DESCRIPTION
## 実装内容
- 通知既読化API実装（POST /api/notifications/:id/read）
- RepositoryにmarkReadを追加し、Supabase経由で更新
- 単体テスト（vitest）を追加し全テスト通過

## 参照設計書
- docs/design/detail/v1.0/feature/api_detail.md

## テスト結果
- [x] 単体テスト: 通過
- [x] 統合テスト: 該当なし
- [x] 手動テスト: 未実施

## 確認事項
- [ ] コードレビュー対象
- [ ] 設計書との整合性確認
- [ ] パフォーマンス確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * You can now mark notifications as read. Unread badges and counts update immediately after you read a notification, and the read state persists across sessions.
* **Bug Fixes**
  * Improved permission checks and clearer error messages when attempting to read notifications without the required access.
* **Tests**
  * Added coverage to ensure correct behavior for successful reads, unauthorized access, and missing household context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->