### PR TITLE
API-027: 日次集計（GET /api/reports/daily-totals）

### DIFF
--- a/web/app/api/reports/daily-totals/route.ts
+++ b/web/app/api/reports/daily-totals/route.ts
@@ -1,0 +1,28 @@
+import { NextRequest, NextResponse } from 'next/server'
+import { assertHouseholdMember, getSession } from '@/server/utils/auth'
+import { badRequest, normalizeError, toErrorBody } from '@/server/utils/errors'
+import { reportsRepository } from '@/server/repositories/reportsRepository'
+
+function isMonth(v: string) {
+  return /^\d{4}-\d{2}$/.test(v)
+}
+
+export async function GET(req: NextRequest) {
+  try {
+    const session = await getSession(req)
+    await assertHouseholdMember(session)
+
+    const url = new URL(req.url)
+    const month = url.searchParams.get('month') || undefined
+
+    if (!month) throw badRequest('month is required')
+    if (!isMonth(month)) throw badRequest('month must be YYYY-MM')
+
+    const data = await reportsRepository.getDailyTotals(session.householdId!, month)
+    return NextResponse.json(data, { status: 200 })
+  } catch (e: unknown) {
+    const err = normalizeError(e)
+    return NextResponse.json(toErrorBody(err), { status: err.status })
+  }
+}
+

--- a/web/server/repositories/reportsRepository.ts
+++ b/web/server/repositories/reportsRepository.ts
@@ -1,0 +1,21 @@
+import { createSupabaseAdmin } from '@/server/clients/supabase'
+
+export type DailyTotal = {
+  day: string
+  income: number
+  expense: number
+  diff: number
+}
+
+export const reportsRepository = {
+  async getDailyTotals(householdId: string, month: string): Promise<DailyTotal[]> {
+    const supabase = createSupabaseAdmin()
+    const { data, error } = await supabase.rpc('get_daily_totals', {
+      _household: householdId,
+      _month: month,
+    })
+    if (error) throw error
+    return (data ?? []) as DailyTotal[]
+  },
+}
+

--- a/web/tests/api/reports_daily_totals.test.ts
+++ b/web/tests/api/reports_daily_totals.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import type { NextRequest } from 'next/server'
+
+// System under test
+import * as route from '@/app/api/reports/daily-totals/route'
+
+// Mocks
+vi.mock('@/server/utils/auth', () => ({
+  getSession: vi.fn(),
+  assertHouseholdMember: vi.fn(),
+}))
+
+vi.mock('@/server/repositories/reportsRepository', () => ({
+  reportsRepository: {
+    getDailyTotals: vi.fn(),
+  },
+}))
+
+import * as authModule from '@/server/utils/auth'
+import type { Session } from '@/server/utils/auth'
+import * as repoModule from '@/server/repositories/reportsRepository'
+import type { DailyTotal } from '@/server/repositories/reportsRepository'
+import { unauthorized, forbidden } from '@/server/utils/errors'
+
+function makeReq(url: string, headers: Record<string, string> = {}): NextRequest {
+  const h = new Headers(headers)
+  return {
+    headers: h,
+    url,
+  } as unknown as NextRequest
+}
+
+describe('GET /api/reports/daily-totals', () => {
+  const getSession = vi.mocked(authModule.getSession)
+  const assertHouseholdMember = vi.mocked(authModule.assertHouseholdMember)
+  const reportsRepository = vi.mocked(repoModule.reportsRepository)
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('returns 401 when unauthorized', async () => {
+    getSession.mockRejectedValue(unauthorized())
+
+    const req = makeReq('https://example.com/api/reports/daily-totals?month=2025-09')
+    const res = await route.GET(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 when household scope missing', async () => {
+    const session: Session = { userId: 'u-1', token: 't' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockRejectedValue(forbidden('household scope required'))
+
+    const req = makeReq('https://example.com/api/reports/daily-totals?month=2025-09')
+    const res = await route.GET(req)
+    expect(res.status).toBe(403)
+    const json = await res.json()
+    expect(json.code).toBe('FORBIDDEN')
+  })
+
+  it('returns 400 when month is missing', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+
+    const req = makeReq('https://example.com/api/reports/daily-totals')
+    const res = await route.GET(req)
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('returns 400 when month is invalid', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+
+    const req = makeReq('https://example.com/api/reports/daily-totals?month=2025-9')
+    const res = await route.GET(req)
+    expect(res.status).toBe(400)
+    const json = await res.json()
+    expect(json.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('returns 200 with daily totals', async () => {
+    const session: Session = { userId: 'u-1', token: 't', householdId: 'h-1' }
+    getSession.mockResolvedValue(session)
+    assertHouseholdMember.mockResolvedValue()
+
+    const rows: DailyTotal[] = [
+      { day: '2025-09-01', income: 1000, expense: 500, diff: 500 },
+      { day: '2025-09-02', income: 0, expense: 0, diff: 0 },
+    ]
+    reportsRepository.getDailyTotals.mockResolvedValue(rows)
+
+    const req = makeReq('https://example.com/api/reports/daily-totals?month=2025-09')
+    const res = await route.GET(req)
+    expect(res.status).toBe(200)
+    const json = await res.json()
+    expect(json).toEqual(rows)
+    expect(reportsRepository.getDailyTotals).toHaveBeenCalledWith('h-1', '2025-09')
+  })
+})
+


### PR DESCRIPTION
## 実装内容
- 日次集計APIルート  を追加
-  で Supabase RPC  を呼び出し
- 月指定  の検証を実装
- 認証/世帯スコープ検証（/）を適用
- 単体テスト追加（未認証/スコープ不足/入力検証/正常系）

## 参照設計書
- docs/design/detail/v1.0/feature/api_detail.md（レポートAPI/RPC呼出）
- docs/design/base/v1.0/api.md（RPC仕様）

## テスト結果
- [x] 単体テスト: 通過（vitest, 5 ケース）
- [x] 統合テスト: N/A（モックベース）
- [x] 手動テスト: N/A

## 確認事項
- [x] コードレビュー対象
- [x] 設計書との整合性確認
- [ ] パフォーマンス確認（実DB環境にて）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an API endpoint to retrieve daily totals for a selected month for the signed-in household.
  * Validates month input (YYYY-MM) and returns structured JSON data.
  * Provides consistent error responses with appropriate status codes.

* **Tests**
  * Added tests for unauthorized access, missing household permissions, missing/invalid month parameter, and successful retrieval.
  * Verifies correct parameters are passed and the response shape and status codes are as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->