### PR TITLE
API-028: Repositoryレイヤ/MCP抽象化 - 単体テスト追加

### DIFF
--- a/web/tests/repositories/commentsRepository.test.ts
+++ b/web/tests/repositories/commentsRepository.test.ts
@@ -1,15 +1,23 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 import { commentsRepository, type Comment } from '@/server/repositories/commentsRepository'
+import { createSupabaseAdmin, type SupabaseAdminClient } from '@/server/clients/supabase'
+import type { CommentCreateInput } from '@/server/schemas/comment'
 
 vi.mock('@/server/clients/supabase', () => ({
   createSupabaseAdmin: vi.fn(),
 }))
 
 type QueryResult<T> = { data: T; error: null } | { data: null; error: Error }
-const ok = <T,>(data: T): QueryResult<T> => ({ data, error: null } as any)
+const ok = <T,>(data: T): QueryResult<T> => ({ data, error: null } as QueryResult<T>)
 
-import { createSupabaseAdmin } from '@/server/clients/supabase'
+interface SelectChain<T> {
+  select: (s: string) => SelectChain<T>
+  eq: (c: string, v: unknown) => SelectChain<T>
+  order?: (c: string, o: { ascending: boolean }) => Promise<QueryResult<T[]>>
+  insert?: (row: unknown) => SelectChain<T>
+  single?: () => Promise<QueryResult<T>>
+}
 
 describe('commentsRepository', () => {
 
@@ -28,15 +36,16 @@ describe('commentsRepository', () => {
       },
     ]
 
-    const chain: any = {
+    const chain: SelectChain<Comment> = {
       select: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
       order: vi.fn().mockResolvedValue(ok(rows)),
     }
 
-    ;(createSupabaseAdmin as any).mockReturnValue({
+    const createSupabaseAdminMock = vi.mocked(createSupabaseAdmin)
+    createSupabaseAdminMock.mockReturnValue({
       from: vi.fn().mockReturnValue(chain),
-    })
+    } as unknown as SupabaseAdminClient)
 
     const result = await commentsRepository.listByTransaction('h1', 't1')
     expect(result).toEqual(rows)
@@ -52,19 +61,18 @@ describe('commentsRepository', () => {
       created_by: 'u1',
       created_at: '2025-09-10T00:00:00Z',
     }
-    const chain: any = {
+    const chain: SelectChain<Comment> = {
       insert: vi.fn().mockReturnThis(),
       select: vi.fn().mockReturnThis(),
       single: vi.fn().mockResolvedValue(ok(created)),
     }
-    ;(createSupabaseAdmin as any).mockReturnValue({
+    const createSupabaseAdminMock = vi.mocked(createSupabaseAdmin)
+    createSupabaseAdminMock.mockReturnValue({
       from: vi.fn().mockReturnValue(chain),
-    })
+    } as unknown as SupabaseAdminClient)
 
-    const result = await commentsRepository.create('h', 'u1', {
-      transaction_id: 't1',
-      body: 'test',
-    } as any)
+    const input: CommentCreateInput = { transaction_id: 't1', body: 'test' }
+    const result = await commentsRepository.create('h', 'u1', input)
     expect(result).toEqual(created)
     expect(chain.insert).toHaveBeenCalled()
   })

--- a/web/tests/repositories/commentsRepository.test.ts
+++ b/web/tests/repositories/commentsRepository.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { commentsRepository, type Comment } from '@/server/repositories/commentsRepository'
+
+vi.mock('@/server/clients/supabase', () => ({
+  createSupabaseAdmin: vi.fn(),
+}))
+
+type QueryResult<T> = { data: T; error: null } | { data: null; error: Error }
+const ok = <T,>(data: T): QueryResult<T> => ({ data, error: null } as any)
+
+import { createSupabaseAdmin } from '@/server/clients/supabase'
+
+describe('commentsRepository', () => {
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('listByTransaction returns ordered comments', async () => {
+    const rows: Comment[] = [
+      {
+        id: 'c1',
+        transaction_id: 't1',
+        body: 'hi',
+        created_by: 'u1',
+        created_at: '2025-09-10T00:00:00Z',
+      },
+    ]
+
+    const chain: any = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue(ok(rows)),
+    }
+
+    ;(createSupabaseAdmin as any).mockReturnValue({
+      from: vi.fn().mockReturnValue(chain),
+    })
+
+    const result = await commentsRepository.listByTransaction('h1', 't1')
+    expect(result).toEqual(rows)
+    expect(chain.eq).toHaveBeenCalledWith('household_id', 'h1')
+    expect(chain.eq).toHaveBeenCalledWith('transaction_id', 't1')
+  })
+
+  it('create inserts and returns created comment', async () => {
+    const created: Comment = {
+      id: 'c2',
+      transaction_id: 't1',
+      body: 'test',
+      created_by: 'u1',
+      created_at: '2025-09-10T00:00:00Z',
+    }
+    const chain: any = {
+      insert: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue(ok(created)),
+    }
+    ;(createSupabaseAdmin as any).mockReturnValue({
+      from: vi.fn().mockReturnValue(chain),
+    })
+
+    const result = await commentsRepository.create('h', 'u1', {
+      transaction_id: 't1',
+      body: 'test',
+    } as any)
+    expect(result).toEqual(created)
+    expect(chain.insert).toHaveBeenCalled()
+  })
+})

--- a/web/tests/repositories/commentsRepository.test.ts
+++ b/web/tests/repositories/commentsRepository.test.ts
@@ -15,8 +15,12 @@ interface SelectChain<T> {
   select: (s: string) => SelectChain<T>
   eq: (c: string, v: unknown) => SelectChain<T>
   order?: (c: string, o: { ascending: boolean }) => Promise<QueryResult<T[]>>
-  insert?: (row: unknown) => SelectChain<T>
-  single?: () => Promise<QueryResult<T>>
+}
+
+interface InsertChain<T> {
+  insert: (row: unknown) => InsertChain<T>
+  select: (s: string) => InsertChain<T>
+  single: () => Promise<QueryResult<T>>
 }
 
 describe('commentsRepository', () => {
@@ -61,7 +65,7 @@ describe('commentsRepository', () => {
       created_by: 'u1',
       created_at: '2025-09-10T00:00:00Z',
     }
-    const chain: SelectChain<Comment> = {
+    const chain: InsertChain<Comment> = {
       insert: vi.fn().mockReturnThis(),
       select: vi.fn().mockReturnThis(),
       single: vi.fn().mockResolvedValue(ok(created)),

--- a/web/tests/repositories/notificationsRepository.test.ts
+++ b/web/tests/repositories/notificationsRepository.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { notificationsRepository, type Notification } from '@/server/repositories/notificationsRepository'
+
+vi.mock('@/server/clients/supabase', () => ({
+  createSupabaseAdmin: vi.fn(),
+}))
+
+type QueryResult<T> = { data: T; error: null } | { data: null; error: Error }
+const ok = <T,>(data: T): QueryResult<T> => ({ data, error: null } as any)
+
+import { createSupabaseAdmin } from '@/server/clients/supabase'
+
+describe('notificationsRepository', () => {
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('list returns notifications; supports onlyUnread flag', async () => {
+    const rows: Notification[] = [
+      {
+        id: 'n1',
+        type: 'comment',
+        payload: { t: 't1' },
+        read: false,
+        created_at: '2025-09-10T00:00:00Z',
+      },
+    ] as any
+
+    const chainBase: any = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+    }
+    let orderCalls = 0
+    chainBase.order = vi.fn().mockImplementation(() => {
+      orderCalls += 1
+      if (orderCalls >= 2) return Promise.resolve(ok(rows))
+      return chainBase
+    })
+
+    const from = vi.fn().mockReturnValue(chainBase)
+
+    ;(createSupabaseAdmin as any).mockReturnValue({ from })
+
+    const result = await notificationsRepository.list('h1', 'u1', { onlyUnread: true })
+    expect(result).toEqual(rows)
+    expect(chainBase.eq).toHaveBeenCalledWith('read', false)
+  })
+
+  it('markRead updates and returns updated row', async () => {
+    const updated: Notification = {
+      id: 'n1',
+      type: 'reaction',
+      payload: {},
+      read: true,
+      created_at: '2025-09-10T00:00:00Z',
+    } as any
+
+    const chain: any = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue(ok(updated)),
+    }
+    ;(createSupabaseAdmin as any).mockReturnValue({
+      from: vi.fn().mockReturnValue(chain),
+    })
+
+    const result = await notificationsRepository.markRead('h', 'u', 'n1')
+    expect(result).toEqual(updated)
+    expect(chain.update).toHaveBeenCalledWith({ read: true })
+  })
+})

--- a/web/tests/repositories/notificationsRepository.test.ts
+++ b/web/tests/repositories/notificationsRepository.test.ts
@@ -1,15 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 import { notificationsRepository, type Notification } from '@/server/repositories/notificationsRepository'
+import { createSupabaseAdmin, type SupabaseAdminClient } from '@/server/clients/supabase'
 
 vi.mock('@/server/clients/supabase', () => ({
   createSupabaseAdmin: vi.fn(),
 }))
 
 type QueryResult<T> = { data: T; error: null } | { data: null; error: Error }
-const ok = <T,>(data: T): QueryResult<T> => ({ data, error: null } as any)
+const ok = <T,>(data: T): QueryResult<T> => ({ data, error: null } as QueryResult<T>)
 
-import { createSupabaseAdmin } from '@/server/clients/supabase'
+interface SelectChain<T> {
+  select: (s: string) => SelectChain<T>
+  eq: (c: string, v: unknown) => SelectChain<T>
+  order: (c: string, o: { ascending: boolean }) => SelectChain<T> | Promise<QueryResult<T[]>>
+}
 
 describe('notificationsRepository', () => {
 
@@ -26,11 +31,11 @@ describe('notificationsRepository', () => {
         read: false,
         created_at: '2025-09-10T00:00:00Z',
       },
-    ] as any
-
-    const chainBase: any = {
+    ]
+    const chainBase: SelectChain<Notification> = {
       select: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
+      order: vi.fn(),
     }
     let orderCalls = 0
     chainBase.order = vi.fn().mockImplementation(() => {
@@ -40,8 +45,8 @@ describe('notificationsRepository', () => {
     })
 
     const from = vi.fn().mockReturnValue(chainBase)
-
-    ;(createSupabaseAdmin as any).mockReturnValue({ from })
+    const createSupabaseAdminMock = vi.mocked(createSupabaseAdmin)
+    createSupabaseAdminMock.mockReturnValue({ from } as unknown as SupabaseAdminClient)
 
     const result = await notificationsRepository.list('h1', 'u1', { onlyUnread: true })
     expect(result).toEqual(rows)
@@ -55,17 +60,24 @@ describe('notificationsRepository', () => {
       payload: {},
       read: true,
       created_at: '2025-09-10T00:00:00Z',
-    } as any
+    }
 
-    const chain: any = {
+    interface UpdateChain<T> {
+      update: (row: unknown) => UpdateChain<T>
+      eq: (c: string, v: unknown) => UpdateChain<T>
+      select: (s: string) => UpdateChain<T>
+      single: () => Promise<QueryResult<T>>
+    }
+    const chain: UpdateChain<Notification> = {
       update: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
       select: vi.fn().mockReturnThis(),
       single: vi.fn().mockResolvedValue(ok(updated)),
     }
-    ;(createSupabaseAdmin as any).mockReturnValue({
+    const createSupabaseAdminMock = vi.mocked(createSupabaseAdmin)
+    createSupabaseAdminMock.mockReturnValue({
       from: vi.fn().mockReturnValue(chain),
-    })
+    } as unknown as SupabaseAdminClient)
 
     const result = await notificationsRepository.markRead('h', 'u', 'n1')
     expect(result).toEqual(updated)

--- a/web/tests/repositories/reactionsRepository.test.ts
+++ b/web/tests/repositories/reactionsRepository.test.ts
@@ -1,15 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 import { reactionsRepository, type Reaction } from '@/server/repositories/reactionsRepository'
+import { createSupabaseAdmin, type SupabaseAdminClient } from '@/server/clients/supabase'
 
 vi.mock('@/server/clients/supabase', () => ({
   createSupabaseAdmin: vi.fn(),
 }))
 
 type QueryResult<T> = { data: T; error: null } | { data: null; error: Error }
-const ok = <T,>(data: T): QueryResult<T> => ({ data, error: null } as any)
+const ok = <T,>(data: T): QueryResult<T> => ({ data, error: null } as QueryResult<T>)
 
-import { createSupabaseAdmin } from '@/server/clients/supabase'
+interface SelectChain<T> {
+  select: (s: string) => SelectChain<T>
+  eq: (c: string, v: unknown) => SelectChain<T>
+  order?: (c: string, o: { ascending: boolean }) => Promise<QueryResult<T[]>>
+  maybeSingle?: () => Promise<QueryResult<T | null>>
+}
 
 describe('reactionsRepository', () => {
 
@@ -26,17 +32,18 @@ describe('reactionsRepository', () => {
         user_id: 'u1',
         created_at: '2025-09-10T00:00:00Z',
       },
-    ] as any
+    ]
 
-    const chain: any = {
+    const chain: SelectChain<Reaction> = {
       select: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
       order: vi.fn().mockResolvedValue(ok(rows)),
     }
 
-    ;(createSupabaseAdmin as any).mockReturnValue({
+    const createSupabaseAdminMock = vi.mocked(createSupabaseAdmin)
+    createSupabaseAdminMock.mockReturnValue({
       from: vi.fn().mockReturnValue(chain),
-    })
+    } as unknown as SupabaseAdminClient)
 
     const result = await reactionsRepository.listByTransaction('h1', 't1')
     expect(result).toEqual(rows)
@@ -51,16 +58,17 @@ describe('reactionsRepository', () => {
       emoji: '❤️',
       user_id: 'u2',
       created_at: '2025-09-10T00:00:00Z',
-    } as any
+    }
 
-    const chain: any = {
+    const chain: SelectChain<Reaction> = {
       select: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
       maybeSingle: vi.fn().mockResolvedValue(ok(one)),
     }
-    ;(createSupabaseAdmin as any).mockReturnValue({
+    const createSupabaseAdminMock = vi.mocked(createSupabaseAdmin)
+    createSupabaseAdminMock.mockReturnValue({
       from: vi.fn().mockReturnValue(chain),
-    })
+    } as unknown as SupabaseAdminClient)
 
     const found = await reactionsRepository.findByUserAndTransaction('h', 't1', 'u2')
     expect(found).toEqual(one)

--- a/web/tests/repositories/reactionsRepository.test.ts
+++ b/web/tests/repositories/reactionsRepository.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { reactionsRepository, type Reaction } from '@/server/repositories/reactionsRepository'
+
+vi.mock('@/server/clients/supabase', () => ({
+  createSupabaseAdmin: vi.fn(),
+}))
+
+type QueryResult<T> = { data: T; error: null } | { data: null; error: Error }
+const ok = <T,>(data: T): QueryResult<T> => ({ data, error: null } as any)
+
+import { createSupabaseAdmin } from '@/server/clients/supabase'
+
+describe('reactionsRepository', () => {
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('listByTransaction returns ordered reactions', async () => {
+    const rows: Reaction[] = [
+      {
+        id: 'r1',
+        transaction_id: 't1',
+        emoji: '👍',
+        user_id: 'u1',
+        created_at: '2025-09-10T00:00:00Z',
+      },
+    ] as any
+
+    const chain: any = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue(ok(rows)),
+    }
+
+    ;(createSupabaseAdmin as any).mockReturnValue({
+      from: vi.fn().mockReturnValue(chain),
+    })
+
+    const result = await reactionsRepository.listByTransaction('h1', 't1')
+    expect(result).toEqual(rows)
+    expect(chain.eq).toHaveBeenCalledWith('household_id', 'h1')
+    expect(chain.eq).toHaveBeenCalledWith('transaction_id', 't1')
+  })
+
+  it('findByUserAndTransaction returns a reaction or null', async () => {
+    const one: Reaction = {
+      id: 'r2',
+      transaction_id: 't1',
+      emoji: '❤️',
+      user_id: 'u2',
+      created_at: '2025-09-10T00:00:00Z',
+    } as any
+
+    const chain: any = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue(ok(one)),
+    }
+    ;(createSupabaseAdmin as any).mockReturnValue({
+      from: vi.fn().mockReturnValue(chain),
+    })
+
+    const found = await reactionsRepository.findByUserAndTransaction('h', 't1', 'u2')
+    expect(found).toEqual(one)
+  })
+})

--- a/web/tests/repositories/subscriptionsRepository.test.ts
+++ b/web/tests/repositories/subscriptionsRepository.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { subscriptionsRepository } from '@/server/repositories/subscriptionsRepository'
+
+vi.mock('@/server/clients/supabase', () => ({
+  createSupabaseAdmin: vi.fn(),
+}))
+
+type QueryResult<T> = { data: T; error: null } | { data: null; error: Error }
+const ok = <T,>(data: T): QueryResult<T> => ({ data, error: null } as any)
+
+import { createSupabaseAdmin } from '@/server/clients/supabase'
+
+describe('subscriptionsRepository', () => {
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('list returns subscriptions ordered', async () => {
+    const rows = [
+      {
+        id: 's1',
+        name: 'Netflix',
+        expected_amount: 1000,
+        category_id: 'c',
+        account_id: 'a',
+        billing_day: 10,
+        note: null,
+      },
+    ]
+
+    const chain: any = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+    }
+    let orderCalls = 0
+    chain.order = vi.fn().mockImplementation(() => {
+      orderCalls += 1
+      if (orderCalls >= 2) return Promise.resolve(ok(rows))
+      return chain
+    })
+
+    ;(createSupabaseAdmin as any).mockReturnValue({
+      from: vi.fn().mockReturnValue(chain),
+    })
+
+    const result = await subscriptionsRepository.list('h1')
+    expect(result).toEqual(rows)
+    expect(chain.eq).toHaveBeenCalledWith('household_id', 'h1')
+  })
+
+  it('confirm calls RPC and fetches created transaction', async () => {
+    const subRow = { id: 's1', expected_amount: 1200, billing_day: 15 }
+    const txRow = {
+      id: 'tx1',
+      kind: 'expense',
+      occurred_on: '2025-09-15',
+      amount: 1200,
+      category_id: 'c',
+      account_id: 'a',
+      place: null,
+      memo: null,
+    }
+
+    const fromSelectSingle = vi.fn()
+    fromSelectSingle.mockResolvedValueOnce(ok(subRow)) // first single() for subscription
+    fromSelectSingle.mockResolvedValueOnce(ok(txRow)) // second single() for transaction fetch
+
+    const fromChainFirst: any = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: fromSelectSingle,
+    }
+
+    const fromChainSecond: any = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: fromSelectSingle,
+    }
+
+    const rpc = vi.fn().mockResolvedValue(ok([{ id: 'tx1' }]))
+
+    const from = vi
+      .fn()
+      .mockReturnValueOnce(fromChainFirst)
+      .mockReturnValueOnce(fromChainSecond)
+
+    ;(createSupabaseAdmin as any).mockReturnValue({
+      from,
+      rpc,
+    })
+
+    const result = await subscriptionsRepository.confirm('h', 's1', {
+      userId: 'u1',
+    })
+    expect(result).toEqual(txRow)
+    expect(rpc).toHaveBeenCalledWith('confirm_subscription_tx', expect.any(Object))
+  })
+})

--- a/web/tests/repositories/subscriptionsRepository.test.ts
+++ b/web/tests/repositories/subscriptionsRepository.test.ts
@@ -1,15 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 import { subscriptionsRepository } from '@/server/repositories/subscriptionsRepository'
+import { createSupabaseAdmin, type SupabaseAdminClient } from '@/server/clients/supabase'
 
 vi.mock('@/server/clients/supabase', () => ({
   createSupabaseAdmin: vi.fn(),
 }))
 
 type QueryResult<T> = { data: T; error: null } | { data: null; error: Error }
-const ok = <T,>(data: T): QueryResult<T> => ({ data, error: null } as any)
+const ok = <T,>(data: T): QueryResult<T> => ({ data, error: null } as QueryResult<T>)
 
-import { createSupabaseAdmin } from '@/server/clients/supabase'
+interface SelectChain<T> {
+  select: (s: string) => SelectChain<T>
+  eq: (c: string, v: unknown) => SelectChain<T>
+  order?: (c: string, o: { ascending: boolean }) => SelectChain<T> | Promise<QueryResult<T[]>>
+  single?: () => Promise<QueryResult<T>>
+}
 
 describe('subscriptionsRepository', () => {
 
@@ -30,9 +36,23 @@ describe('subscriptionsRepository', () => {
       },
     ]
 
-    const chain: any = {
+    interface OrderableChain<T> {
+      select: (s: string) => OrderableChain<T>
+      eq: (c: string, v: unknown) => OrderableChain<T>
+      order: (c: string, o: { ascending: boolean }) => OrderableChain<T> | Promise<QueryResult<T[]>>
+    }
+    const chain: OrderableChain<{
+      id: string
+      name: string
+      expected_amount: number
+      category_id: string
+      account_id: string
+      billing_day: number
+      note: string | null
+    }> = {
       select: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
+      order: vi.fn(),
     }
     let orderCalls = 0
     chain.order = vi.fn().mockImplementation(() => {
@@ -41,9 +61,10 @@ describe('subscriptionsRepository', () => {
       return chain
     })
 
-    ;(createSupabaseAdmin as any).mockReturnValue({
+    const createSupabaseAdminMock = vi.mocked(createSupabaseAdmin)
+    createSupabaseAdminMock.mockReturnValue({
       from: vi.fn().mockReturnValue(chain),
-    })
+    } as unknown as SupabaseAdminClient)
 
     const result = await subscriptionsRepository.list('h1')
     expect(result).toEqual(rows)
@@ -67,29 +88,46 @@ describe('subscriptionsRepository', () => {
     fromSelectSingle.mockResolvedValueOnce(ok(subRow)) // first single() for subscription
     fromSelectSingle.mockResolvedValueOnce(ok(txRow)) // second single() for transaction fetch
 
-    const fromChainFirst: any = {
+    interface SingleChain<T> {
+      select: (s: string) => SingleChain<T>
+      eq: (c: string, v: unknown) => SingleChain<T>
+      single: () => Promise<QueryResult<T>>
+    }
+    const fromChainFirst: SingleChain<{ id: string; expected_amount: number; billing_day: number }> = {
       select: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
       single: fromSelectSingle,
     }
 
-    const fromChainSecond: any = {
+    const fromChainSecond: SingleChain<{
+      id: string
+      kind: 'income' | 'expense'
+      occurred_on: string
+      amount: number
+      category_id: string
+      account_id: string
+      place: string | null
+      memo: string | null
+    }> = {
       select: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
       single: fromSelectSingle,
     }
 
-    const rpc = vi.fn().mockResolvedValue(ok([{ id: 'tx1' }]))
+    const rpc: (fn: string, args: Record<string, unknown>) => Promise<QueryResult<unknown>> = vi
+      .fn()
+      .mockResolvedValue(ok([{ id: 'tx1' }]))
 
     const from = vi
       .fn()
       .mockReturnValueOnce(fromChainFirst)
       .mockReturnValueOnce(fromChainSecond)
 
-    ;(createSupabaseAdmin as any).mockReturnValue({
+    const createSupabaseAdminMock = vi.mocked(createSupabaseAdmin)
+    createSupabaseAdminMock.mockReturnValue({
       from,
       rpc,
-    })
+    } as unknown as SupabaseAdminClient)
 
     const result = await subscriptionsRepository.confirm('h', 's1', {
       userId: 'u1',

--- a/web/tests/repositories/transactionsRepository.test.ts
+++ b/web/tests/repositories/transactionsRepository.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 // Module under test
 import { transactionsRepository, type Transaction } from '@/server/repositories/transactionsRepository'
+import { createSupabaseAdmin, type SupabaseAdminClient } from '@/server/clients/supabase'
 
 // Mock supabase admin client factory
 vi.mock('@/server/clients/supabase', () => ({
@@ -11,10 +12,18 @@ vi.mock('@/server/clients/supabase', () => ({
 type QueryResult<T> = { data: T; error: null } | { data: null; error: Error }
 
 function ok<T>(data: T): QueryResult<T> {
-  return { data, error: null } as any
+  return { data, error: null } as QueryResult<T>
 }
 
-import { createSupabaseAdmin } from '@/server/clients/supabase'
+interface SelectChain<T> {
+  select: (s: string) => SelectChain<T>
+  eq: (c: string, v: unknown) => SelectChain<T>
+  gte?: (c: string, v: unknown) => SelectChain<T>
+  lt?: (c: string, v: unknown) => SelectChain<T>
+  order?: (c: string, o: { ascending: boolean }) => SelectChain<T>
+  single?: () => Promise<QueryResult<T>>
+  then?: (resolve: (r: QueryResult<T[]>) => unknown) => unknown
+}
 
 describe('transactionsRepository', () => {
 
@@ -36,28 +45,31 @@ describe('transactionsRepository', () => {
       },
     ]
 
-    const chain: any = {
+    const chain: SelectChain<Transaction> = {
       select: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
       gte: vi.fn().mockReturnThis(),
       lt: vi.fn().mockReturnThis(),
+      order: vi.fn(),
+      then: undefined,
     }
     chain.order = vi.fn().mockReturnValue(chain)
     // Make the builder thenable so `await query` resolves to `{ data, error }`
-    chain.then = (resolve: any) => resolve(ok(records))
-    ;(createSupabaseAdmin as any).mockReturnValue({
+    chain.then = (resolve: (v: QueryResult<Transaction[]>) => unknown) => resolve(ok(records))
+    const createSupabaseAdminMock = vi.mocked(createSupabaseAdmin)
+    createSupabaseAdminMock.mockReturnValue({
       from: vi.fn().mockReturnValue({
         ...chain,
         then: undefined,
       }),
-    })
+    } as unknown as SupabaseAdminClient)
 
     // final awaited value resolved via order implementation above
 
     const result = await transactionsRepository.listByMonth('h1', '2025-09', 'expense')
     expect(result).toEqual(records)
 
-    expect((createSupabaseAdmin as any).mock.calls.length).toBe(1)
+    expect(vi.mocked(createSupabaseAdmin).mock.calls.length).toBe(1)
     expect(chain.eq).toHaveBeenCalledWith('household_id', 'h1')
     expect(chain.gte).toHaveBeenCalledWith('occurred_on', '2025-09-01')
     expect(chain.lt).toHaveBeenCalledWith('occurred_on', '2025-10-01')
@@ -76,14 +88,15 @@ describe('transactionsRepository', () => {
       memo: 'hello',
     }
 
-    const chain: any = {
+    const chain: SelectChain<Transaction> = {
       insert: vi.fn().mockReturnThis(),
       select: vi.fn().mockReturnThis(),
       single: vi.fn().mockResolvedValue(ok(created)),
     }
-    ;(createSupabaseAdmin as any).mockReturnValue({
+    const createSupabaseAdminMock2 = vi.mocked(createSupabaseAdmin)
+    createSupabaseAdminMock2.mockReturnValue({
       from: vi.fn().mockReturnValue(chain),
-    })
+    } as unknown as SupabaseAdminClient)
 
     const result = await transactionsRepository.create('house', {
       kind: 'income',
@@ -92,7 +105,7 @@ describe('transactionsRepository', () => {
       category_id: 'cat',
       account_id: 'acc',
       memo: 'hello',
-    } as any)
+    })
 
     expect(result).toEqual(created)
     expect(chain.insert).toHaveBeenCalled()

--- a/web/tests/repositories/transactionsRepository.test.ts
+++ b/web/tests/repositories/transactionsRepository.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Module under test
+import { transactionsRepository, type Transaction } from '@/server/repositories/transactionsRepository'
+
+// Mock supabase admin client factory
+vi.mock('@/server/clients/supabase', () => ({
+  createSupabaseAdmin: vi.fn(),
+}))
+
+type QueryResult<T> = { data: T; error: null } | { data: null; error: Error }
+
+function ok<T>(data: T): QueryResult<T> {
+  return { data, error: null } as any
+}
+
+import { createSupabaseAdmin } from '@/server/clients/supabase'
+
+describe('transactionsRepository', () => {
+
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('listByMonth returns ordered transactions and supports kind filter', async () => {
+    const records: Transaction[] = [
+      {
+        id: 't1',
+        kind: 'expense',
+        occurred_on: '2025-09-02',
+        amount: 1200,
+        category_id: 'c1',
+        account_id: 'a1',
+        place: null,
+        memo: null,
+      },
+    ]
+
+    const chain: any = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      gte: vi.fn().mockReturnThis(),
+      lt: vi.fn().mockReturnThis(),
+    }
+    chain.order = vi.fn().mockReturnValue(chain)
+    // Make the builder thenable so `await query` resolves to `{ data, error }`
+    chain.then = (resolve: any) => resolve(ok(records))
+    ;(createSupabaseAdmin as any).mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        ...chain,
+        then: undefined,
+      }),
+    })
+
+    // final awaited value resolved via order implementation above
+
+    const result = await transactionsRepository.listByMonth('h1', '2025-09', 'expense')
+    expect(result).toEqual(records)
+
+    expect((createSupabaseAdmin as any).mock.calls.length).toBe(1)
+    expect(chain.eq).toHaveBeenCalledWith('household_id', 'h1')
+    expect(chain.gte).toHaveBeenCalledWith('occurred_on', '2025-09-01')
+    expect(chain.lt).toHaveBeenCalledWith('occurred_on', '2025-10-01')
+    expect(chain.eq).toHaveBeenCalledWith('kind', 'expense')
+  })
+
+  it('create inserts and returns created row', async () => {
+    const created: Transaction = {
+      id: 'tx-new',
+      kind: 'income',
+      occurred_on: '2025-09-09',
+      amount: 3000,
+      category_id: 'cat',
+      account_id: 'acc',
+      place: null,
+      memo: 'hello',
+    }
+
+    const chain: any = {
+      insert: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue(ok(created)),
+    }
+    ;(createSupabaseAdmin as any).mockReturnValue({
+      from: vi.fn().mockReturnValue(chain),
+    })
+
+    const result = await transactionsRepository.create('house', {
+      kind: 'income',
+      occurred_on: '2025-09-09',
+      amount: 3000,
+      category_id: 'cat',
+      account_id: 'acc',
+      memo: 'hello',
+    } as any)
+
+    expect(result).toEqual(created)
+    expect(chain.insert).toHaveBeenCalled()
+    expect(chain.single).toHaveBeenCalled()
+  })
+})

--- a/web/tests/repositories/transactionsRepository.test.ts
+++ b/web/tests/repositories/transactionsRepository.test.ts
@@ -15,14 +15,19 @@ function ok<T>(data: T): QueryResult<T> {
   return { data, error: null } as QueryResult<T>
 }
 
-interface SelectChain<T> {
-  select: (s: string) => SelectChain<T>
-  eq: (c: string, v: unknown) => SelectChain<T>
-  gte?: (c: string, v: unknown) => SelectChain<T>
-  lt?: (c: string, v: unknown) => SelectChain<T>
-  order?: (c: string, o: { ascending: boolean }) => SelectChain<T>
-  single?: () => Promise<QueryResult<T>>
+interface QueryChain<T> {
+  select: (s: string) => QueryChain<T>
+  eq: (c: string, v: unknown) => QueryChain<T>
+  gte?: (c: string, v: unknown) => QueryChain<T>
+  lt?: (c: string, v: unknown) => QueryChain<T>
+  order?: (c: string, o: { ascending: boolean }) => QueryChain<T>
   then?: (resolve: (r: QueryResult<T[]>) => unknown) => unknown
+}
+
+interface InsertChain<T> {
+  insert: (row: unknown) => InsertChain<T>
+  select: (s: string) => InsertChain<T>
+  single: () => Promise<QueryResult<T>>
 }
 
 describe('transactionsRepository', () => {
@@ -45,7 +50,7 @@ describe('transactionsRepository', () => {
       },
     ]
 
-    const chain: SelectChain<Transaction> = {
+    const chain: QueryChain<Transaction> = {
       select: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
       gte: vi.fn().mockReturnThis(),
@@ -88,7 +93,7 @@ describe('transactionsRepository', () => {
       memo: 'hello',
     }
 
-    const chain: SelectChain<Transaction> = {
+    const chain: InsertChain<Transaction> = {
       insert: vi.fn().mockReturnThis(),
       select: vi.fn().mockReturnThis(),
       single: vi.fn().mockResolvedValue(ok(created)),


### PR DESCRIPTION
## 実装内容
- Repositoryレイヤの単体テストを追加（transactions/subscriptions/comments/reactions/notifications）
- Supabaseクライアントをモックしたテストで主要メソッドの戻り値・クエリ連鎖を検証

## 参照設計書
- docs/design/detail/v1.0/feature/backend_detail.md

## テスト結果
- [x] 単体テスト: 通過（111件）
- [x] 統合テスト: 既存APIテストも全て通過
- [ ] 手動テスト: 対象外

## 確認事項
- [x] コードレビュー対象
- [x] 設計書との整合性確認
- [ ] パフォーマンス確認（ユニットテストのため対象外）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for comments, notifications, reactions, subscriptions, and transactions flows.
  * Verifies listing with filters and ordering, creation of records, marking notifications as read, confirming subscriptions, and monthly transaction queries.
  * Strengthens reliability of core user experiences (activity feeds, reactions, notifications, subscriptions, and expense tracking) and reduces risk of regressions.
  * No user-facing behavior changes; improves confidence in existing features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->