### PR TITLE
FE-002: 認証/初回セットアップ画面

### DIFF
--- a/web/app/auth/page.tsx
+++ b/web/app/auth/page.tsx
@@ -27,8 +27,9 @@ export default function AuthPage() {
       if (error) throw error
       show(mode === "signin" ? "サインイン成功" : "サインアップ成功", "success")
       router.replace("/setup")
-    } catch (err: any) {
-      show(err?.message ?? "認証エラーが発生しました", "error")
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "認証エラーが発生しました"
+      show(message, "error")
     } finally {
       setLoading(false)
     }

--- a/web/app/auth/page.tsx
+++ b/web/app/auth/page.tsx
@@ -1,0 +1,60 @@
+"use client"
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { createSupabaseBrowser } from "@/lib/supabaseBrowser"
+import { useToast } from "@/components/ui/toast"
+import { Input } from "@/components/ui/input"
+import { Button } from "@/components/ui/button"
+
+export default function AuthPage() {
+  const [mode, setMode] = useState<"signin" | "signup">("signin")
+  const [email, setEmail] = useState("")
+  const [password, setPassword] = useState("")
+  const [loading, setLoading] = useState(false)
+  const router = useRouter()
+  const { show } = useToast()
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setLoading(true)
+    try {
+      const supabase = createSupabaseBrowser()
+      const fn =
+        mode === "signin"
+          ? supabase.auth.signInWithPassword({ email, password })
+          : supabase.auth.signUp({ email, password })
+      const { error } = await fn
+      if (error) throw error
+      show(mode === "signin" ? "サインイン成功" : "サインアップ成功", "success")
+      router.replace("/setup")
+    } catch (err: any) {
+      show(err?.message ?? "認証エラーが発生しました", "error")
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <main className="mx-auto max-w-md px-6 py-10">
+      <h1 className="mb-6 text-2xl font-semibold">{mode === "signin" ? "サインイン" : "サインアップ"}</h1>
+      <div className="mb-4 space-x-2">
+        <Button variant={mode === "signin" ? "default" : "secondary"} onClick={() => setMode("signin")}>サインイン</Button>
+        <Button variant={mode === "signup" ? "default" : "secondary"} onClick={() => setMode("signup")}>サインアップ</Button>
+      </div>
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="mb-1 block text-sm">メールアドレス</label>
+          <Input type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
+        </div>
+        <div>
+          <label className="mb-1 block text-sm">パスワード</label>
+          <Input type="password" value={password} onChange={(e) => setPassword(e.target.value)} required />
+        </div>
+        <Button type="submit" disabled={loading}>
+          {loading ? "処理中..." : mode === "signin" ? "サインイン" : "サインアップ"}
+        </Button>
+      </form>
+    </main>
+  )
+}
+

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import { ToastProvider } from "@/components/ui/toast";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -27,7 +28,9 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <ToastProvider>
+          {children}
+        </ToastProvider>
       </body>
     </html>
   );

--- a/web/app/setup/page.tsx
+++ b/web/app/setup/page.tsx
@@ -1,0 +1,87 @@
+"use client"
+import { useState } from "react"
+import { useRouter } from "next/navigation"
+import { Button } from "@/components/ui/button"
+import { Input } from "@/components/ui/input"
+import { useToast } from "@/components/ui/toast"
+
+async function postJson(path: string, body: any) {
+  const res = await fetch(path, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  })
+  const json = await res.json().catch(() => ({}))
+  if (!res.ok) {
+    const msg = json?.message || `Request failed: ${res.status}`
+    throw new Error(msg)
+  }
+  return json
+}
+
+export default function SetupPage() {
+  const [name, setName] = useState("")
+  const [token, setToken] = useState("")
+  const [loadingCreate, setLoadingCreate] = useState(false)
+  const [loadingJoin, setLoadingJoin] = useState(false)
+  const router = useRouter()
+  const { show } = useToast()
+
+  async function createHousehold(e: React.FormEvent) {
+    e.preventDefault()
+    setLoadingCreate(true)
+    try {
+      await postJson("/api/households", { name })
+      show("世帯を作成しました", "success")
+      router.replace("/")
+    } catch (err: any) {
+      show(err?.message ?? "世帯作成に失敗しました", "error")
+    } finally {
+      setLoadingCreate(false)
+    }
+  }
+
+  async function joinHousehold(e: React.FormEvent) {
+    e.preventDefault()
+    setLoadingJoin(true)
+    try {
+      await postJson("/api/households/join", { token })
+      show("世帯に参加しました", "success")
+      router.replace("/")
+    } catch (err: any) {
+      show(err?.message ?? "参加に失敗しました", "error")
+    } finally {
+      setLoadingJoin(false)
+    }
+  }
+
+  return (
+    <main className="mx-auto grid max-w-2xl gap-10 px-6 py-10 md:grid-cols-2">
+      <section>
+        <h2 className="mb-4 text-xl font-semibold">世帯を作成</h2>
+        <form onSubmit={createHousehold} className="space-y-4">
+          <div>
+            <label className="mb-1 block text-sm">世帯名</label>
+            <Input value={name} onChange={(e) => setName(e.target.value)} required />
+          </div>
+          <Button type="submit" disabled={loadingCreate}>
+            {loadingCreate ? "作成中..." : "作成"}
+          </Button>
+        </form>
+      </section>
+      <section>
+        <h2 className="mb-4 text-xl font-semibold">招待トークンで参加</h2>
+        <form onSubmit={joinHousehold} className="space-y-4">
+          <div>
+            <label className="mb-1 block text-sm">招待トークン</label>
+            <Input value={token} onChange={(e) => setToken(e.target.value)} required />
+          </div>
+          <Button type="submit" disabled={loadingJoin}>
+            {loadingJoin ? "参加中..." : "参加"}
+          </Button>
+        </form>
+      </section>
+    </main>
+  )
+}
+

--- a/web/app/setup/page.tsx
+++ b/web/app/setup/page.tsx
@@ -5,18 +5,20 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { useToast } from "@/components/ui/toast"
 
-async function postJson(path: string, body: any) {
+type Json = Record<string, unknown>
+
+async function postJson<T = unknown>(path: string, body: Json): Promise<T> {
   const res = await fetch(path, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
   })
-  const json = await res.json().catch(() => ({}))
+  const json = (await res.json().catch(() => ({}))) as unknown
   if (!res.ok) {
-    const msg = json?.message || `Request failed: ${res.status}`
+    const msg = (json as { message?: string })?.message || `Request failed: ${res.status}`
     throw new Error(msg)
   }
-  return json
+  return json as T
 }
 
 export default function SetupPage() {
@@ -34,8 +36,9 @@ export default function SetupPage() {
       await postJson("/api/households", { name })
       show("世帯を作成しました", "success")
       router.replace("/")
-    } catch (err: any) {
-      show(err?.message ?? "世帯作成に失敗しました", "error")
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "世帯作成に失敗しました"
+      show(message, "error")
     } finally {
       setLoadingCreate(false)
     }
@@ -48,8 +51,9 @@ export default function SetupPage() {
       await postJson("/api/households/join", { token })
       show("世帯に参加しました", "success")
       router.replace("/")
-    } catch (err: any) {
-      show(err?.message ?? "参加に失敗しました", "error")
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : "参加に失敗しました"
+      show(message, "error")
     } finally {
       setLoadingJoin(false)
     }


### PR DESCRIPTION
## 実装内容
- /auth 画面でのメール/パスワード サインイン/サインアップ
- /setup 画面での世帯作成と招待トークンでの参加
- ToastProvider を layout に導入してエラーハンドリング/通知を実装

## 参照設計書
- docs/design/detail/v1.0/ui/ui_screens.md（認証/セットアップ）
- docs/design/base/v1.0/ui.md
- docs/design/detail/v1.0/feature/api_detail.md

## テスト結果
- [x] 単体テスト: 通過
- [x] 統合テスト: 通過
- [x] 手動テスト: 画面遷移とAPI連携を確認

## 確認事項
- [x] コードレビュー対象
- [x] 設計書との整合性確認
- [x] パフォーマンス確認

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authentication page with sign-in/sign-up toggle, email/password inputs, loading states, localized success/error toasts, and redirect to setup on success.
  * Added a setup page to create or join a household via invitation token, with separate forms, loading states, toasts, and redirect to home on success.
  * Enabled global toast notifications across the app for consistent feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->